### PR TITLE
modify echo-by-zip

### DIFF
--- a/echo-by-zip.ipynb
+++ b/echo-by-zip.ipynb
@@ -4,9 +4,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Exploring ECHO Data in Your Area\n",
-    "This workbook is a way to quickly view data from EPA's Enforcement and Compliance History Online portal that is relevant just to your area.\n",
-    "It is designed to work with the [ECHO Exporter](https://echo.epa.gov/tools/data-downloads#exporter) file."
+    "# Environmental Crime\n",
+    "This workbook is a way to quickly view data from EPA's Enforcement and Compliance History Online portal that is relevant to your city. ECHO is the major repository of the U.S. Environmental Protection Agency for public data on its oversight and enforcement activities. It contains information on most if not all of the facilities regulated by the agency for their compliance with our major environmental laws. ([EPA’s “about ECHO data” page](https://echo.epa.gov/resources/echo-data/about-the-data))\n",
+    "\n",
+    "The workbook shows you the cost, in dollar terms, of the climate change-causing greenhouse gases industries in your city are allowed to release, and whether enforcement actions are taken against facilities who violate the Clean Air Act."
    ]
   },
   {
@@ -23,27 +24,57 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# **Let's begin!**\n",
+    "# **Let's begin**\n",
     "Hover over the \"[ ]\" on the top left corner of the cell below and you should see a \"play\" button appear. Click on it to run the cell then move to the next one.¶\n",
-    "### Run this next cell to create the widget for inputting your zip code. It will create an input field at the bottom. Enter your zip code and then move on to the next cell, or choose Run All as described above."
+    "### Run this next cell to create the widget for inputting your zip code. It will create an input field at the bottom. Enter your city and state and then move on to the next cell, or choose Run All as described above."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e50ad62975834a19a025ba4ba211367d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Text(value='Minneapolis', description='City: ')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ee446021415a44078068bcfa6d06bbbd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Dropdown(description='State:', index=23, options=('AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DC', 'DE', 'FL', …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Import libraries\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",
+    "from matplotlib.ticker import MaxNLocator\n",
     "import folium\n",
     "import urllib.parse\n",
     "from ipywidgets import interact, interactive, fixed, interact_manual\n",
     "import ipywidgets as widgets\n",
-    "from IPython.display import display\n",
+    "from IPython.display import display, HTML\n",
     "\n",
     "def get_data( sql, index_field = None ):\n",
     "    url='http://apps.tlt.stonybrook.edu/echoepa/?query='\n",
@@ -53,21 +84,35 @@
     "        ds.set_index( index_field, inplace=True)\n",
     "    return ds\n",
     "\n",
-    "zip_widget = widgets.IntText(\n",
-    "    value=1,\n",
-    "    description='Zip Code:',\n",
+    "city_widget = widgets.Text(\n",
+    "    value=\"Minneapolis\",\n",
+    "    description='City: ',\n",
     "    disabled=False\n",
     ")\n",
-    "display( zip_widget )"
+    "display( city_widget )\n",
+    "\n",
+    "states = [\"AL\", \"AK\", \"AZ\", \"AR\", \"CA\", \"CO\", \"CT\", \"DC\", \"DE\", \"FL\", \"GA\", \n",
+    "          \"HI\", \"ID\", \"IL\", \"IN\", \"IA\", \"KS\", \"KY\", \"LA\", \"ME\", \"MD\", \n",
+    "          \"MA\", \"MI\", \"MN\", \"MS\", \"MO\", \"MT\", \"NE\", \"NV\", \"NH\", \"NJ\", \n",
+    "          \"NM\", \"NY\", \"NC\", \"ND\", \"OH\", \"OK\", \"OR\", \"PA\", \"RI\", \"SC\", \n",
+    "          \"SD\", \"TN\", \"TX\", \"UT\", \"VT\", \"VA\", \"WA\", \"WV\", \"WI\", \"WY\"]\n",
+    "dropdown_state=widgets.Dropdown(\n",
+    "    options=states,\n",
+    "    value='MN',\n",
+    "    description='State:',\n",
+    "    disabled=False,\n",
+    ")\n",
+    "display (dropdown_state)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_zip = zip_widget.value\n",
+    "my_city = city_widget.value\n",
+    "my_state = dropdown_state.value\n",
     "\n",
     "# Define columns of interest (see the echo_exporter_columns xlsx file that comes bundled with the csv download)\n",
     "# This is not a comprehensive list of columns; more are available.\n",
@@ -77,265 +122,93 @@
     "column_mapping = {\n",
     "    \"REGISTRY_ID\": str,\n",
     "    \"FAC_NAME\": str,\n",
+    "    \"FAC_CITY\": str,\n",
+    "    \"FAC_STATE\": str,\n",
     "    \"FAC_ZIP\": str,\n",
     "    \"FAC_LAT\": float,\n",
     "    \"FAC_LONG\": float,\n",
-    "    \"FAC_QTRS_WITH_NC\": float,\n",
-    "    \"CAA_PERMIT_TYPES\": str,\n",
-    "    \"CWA_PERMIT_TYPES\": str,\n",
-    "    \"RCRA_PERMIT_TYPES\": str,\n",
-    "    \"FAC_3YR_COMPLIANCE_HISTORY\": str,\n",
-    "    \"FAC_INSPECTION_COUNT\": float,\n",
-    "    \"GHG_CO2_RELEASES\": float\n",
+    "    \"GHG_CO2_RELEASES\": float,\n",
+    "    \"AIR_IDS\": str\n",
     "}\n",
-    "# not currently using: \"FAC_INFORMAL_COUNT\", \"FAC_FORMAL_ACTION_COUNT\"\n",
     "column_names = list( column_mapping.keys() )\n",
-    "columns_string = ','.join( column_names )\n"
+    "columns_string = ','.join( column_names )"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Filter to just your zip code\n",
+    "# Filter to just your city\n",
     "\n",
-    "sql = \"select \" + columns_string + \" from ECHO_EXPORTER where FAC_ZIP = \" + str( my_zip )\n",
+    "sql = \"select \" + columns_string + \" from ECHO_EXPORTER where FAC_CITY = '\" + my_city + \"' and FAC_STATE = '\" + my_state + \"'\"\n",
+    "\n",
     "try:\n",
     "    # Use the first column name as the index.\n",
     "    my_echo = get_data( sql, column_names[0] )\n",
     "    num_permits = my_echo.shape[0]\n",
     "except pd.errors.EmptyDataError:\n",
-    "    print(\"\\nThere are no EPA facilities in this zip code.\\n\")"
+    "    print(\"We couldn't find any EPA facilities in \"+my_city+\", \"+my_state+\". This could be because there are no facilities or be because of a problem with the way you spelled the city.\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## How many facilities in your zip code are tracked in the ECHO database?\n",
-    "ECHO is shorthand for Enforcement and Compliance History Online, the major repository of the U.S. Environmental Protection Agency for public data on its oversight and enforcement activities.  ECHO contains information on most if not all of the facilities regulated by the agency for their compliance with our major environmental laws. ([EPA’s “about ECHO data” page](https://echo.epa.gov/resources/echo-data/about-the-data))"
+    "## What facilities in your city report GHGs?"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "There are 4012 facilities in Minneapolis tracked in the ECHO database.\n"
+     ]
+    }
+   ],
    "source": [
     "num_facilities = my_echo.shape[0]\n",
-    "print(\"There are %s facilities in %s tracked in the ECHO database.\" %(num_facilities, my_zip))"
+    "print(\"There are %s facilities in %s tracked in the ECHO database.\" %(num_facilities, my_city))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Let's show a quick map of your area and the facilities in it\n",
-    "\n",
-    "def mapper(dataframe):\n",
-    "    # Initialize the map\n",
-    "    m = folium.Map(\n",
-    "        location = [my_echo.mean()[\"FAC_LAT\"], my_echo.mean()[\"FAC_LONG\"]],\n",
-    "    )\n",
-    "\n",
-    "    # Add a clickable marker for each facility\n",
-    "    for index, row in dataframe.iterrows():\n",
-    "        folium.Marker(\n",
-    "            location = [row[\"FAC_LAT\"], row[\"FAC_LONG\"]],\n",
-    "            popup = row[\"FAC_NAME\"]\n",
-    "        ).add_to(m)\n",
-    "\n",
-    "    bounds = m.get_bounds()\n",
-    "    m.fit_bounds(bounds)\n",
-    "    \n",
-    "    # Show the map\n",
-    "    return m\n",
-    "\n",
-    "map_of_facilities_in_my_area = mapper(my_echo)\n",
-    "map_of_facilities_in_my_area"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## What permit types have been issued in this zip code?\n",
-    "ECHO contains data on EPA’s permitting systems, a chief means by which it administers three major national environmental laws, for clean air (the Clean Air Act, or CAA), clean water (the Clean Water Act, or CWA), and hazardous waste handling (RCRA, or the Resource Recovery and Conservation Act).   Potential or actual emitters of any of these kinds of pollution have to receive a permit from the EPA before they can legally operate, setting a clear limit on the pollution they can emit.   Permitted firms can still pollute some, but only within limits set by the permit.  The agency is supposed to set the allowed emissions at a level that avoids threats to human health and the environment. When a facility’s emissions stay within the permitted limits, it is considered “in compliance.” When its air, water, or hazardous waste emissions exceed the terms of its permit, that’s a violation. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "permit_cols = [\"CAA_PERMIT_TYPES\",\"CWA_PERMIT_TYPES\",\"RCRA_PERMIT_TYPES\"]\n",
-    "\n",
-    "# Get a DataFrame with just the columns relating to permit type\n",
-    "permits = my_echo[permit_cols]\n",
-    "# Count how many non-null values are in each column\n",
-    "counted_permit_types = permits.count()\n",
-    "\n",
-    "# Print how many values are present for each column (permitting law)\n",
-    "print(counted_permit_types)\n",
-    "\n",
-    "# Graph the number of permits by which law they correspond to\n",
-    "plt.bar(counted_permit_types.keys(), counted_permit_types)\n",
-    "plt.ylim(top = num_facilities) # so the top of the graph is the total # of facilities in the region\n",
-    "plt.title(\"Number of Permits of Various Types in %s\" %(my_zip))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To learn more about the several types of permits offered under the Clean Air Act (operating, New Source Review, and others), see EPA’s explanation [here](https://www.epa.gov/caa-permitting).  To learn about the major permitting system under the Clean Water Act, the National Pollutant Discharge Elimination System (NPDES), see EPA’s explanation [here](https://www.epa.gov/npdes).  For more about the EPA’s permitting program for handlers of hazardous waste, click [here](https://www.epa.gov/hwpermitting).\n",
-    "\n",
-    "In its air and water programs, EPA draws a line between “major” polluters, which require permits, and “minor” polluters, few of which do.  [Air polluting facilities, for instance](https://www.epa.gov/title-v-operating-permits/who-has-obtain-title-v-permit), are classified as “major,” and must apply for operating permits, if they actually or potentially emit at least 100 tons of a general air pollutant in a year, or 10 tons of a single “hazardous” air pollutant or 25 of a combination of hazardous chemicals per year.  Most “non-major” air polluters, releasing less than those amounts, aren’t required to have permits unless classified as an especially dangerous industry, like smelting or chemical production."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Drilling down into what types of permits have been issued\n",
-    "\n",
-    "# Define a function for counting permit types\n",
-    "def count_permits(permit_law):\n",
-    "    # Find all the possible permit types\n",
-    "    permit_types_with_nan = my_echo[permit_law].unique().tolist()\n",
-    "    # Remove null value as a permit type\n",
-    "    permit_types = [i for i in permit_types_with_nan if str(i) != \"nan\"] # note that nan values fail to be counted even when left in\n",
-    "    # Define a dictionary to save counted permits\n",
-    "    permits_issued = {}\n",
-    "    # For each permit type...\n",
-    "    for permit_type in permit_types:\n",
-    "        # Count those unique values and save them corresponding to their permit type\n",
-    "        permits_issued[permit_type] = my_echo[my_echo[permit_law] == permit_type].shape[0]\n",
-    "    # Return a tuple naming the law the permit is issued under and a dictionary counting its issued permits\n",
-    "    return (permits_issued)\n",
-    "\n",
-    "# For each permit type\n",
-    "for permit_law in permit_cols:\n",
-    "    counted_permits = count_permits(permit_law)\n",
-    "    \n",
-    "    # Print the raw data\n",
-    "    print(permit_law)\n",
-    "    print(counted_permits)\n",
-    "    \n",
-    "    # Plot a pie chart breaking down type of permit in each category\n",
-    "    plt.pie(counted_permits.values(), labels = list(counted_permits.keys()))\n",
-    "    plt.show()\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "See above for the explanation of “major” and “non-major” air permits; similar distinctions also guide permitting in the [water (CWA)](https://www.epa.gov/npdes-permits/guidance-majorminor-designation-npdes-facilities-region-10) and [hazardous waste (RCRA, CERCLA)](https://www.epa.gov/hwgenerators/categories-hazardous-waste-generators) programs. LQG refers to [“Large Quantity Generators” of hazardous wastes](https://www.epa.gov/hwgenerators/fact-sheet-requirements-large-quantity-generators-hazardous-waste), generating 1,000 kilograms per month or more of hazardous waste or more than one kilogram per month of acutely hazardous waste; SQG to “Small Quantity Generators,” generating less than that, as well as VSQGs or  “very small quantities generators,”– yielding 100 kilograms or less per month of hazardous waste or one kilogram or less per month of acutely hazardous waste."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Are there facilities in my region not in compliance with their permits in the last three years?\n",
-    "\n",
-    "ECHO registers compliance —that a facility’s emissions are within the limits allowed by its permit(s) — by quarter. Those shown to be exceeding their permitted emissions, either through inspections, evaluations, or monitoring data of various kinds, are considered noncompliant, and in violation.  It is worth noting that emissions averaged over a quarter of a year can fail to reflect the level of danger posed by a single and sudden but burst, such as from a massive spill or fire."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# How many facilities have been out of compliance in the last 12 quarters?\n",
-    "\n",
-    "noncompliant = my_echo[my_echo[\"FAC_QTRS_WITH_NC\"] > 0].sort_values(by=\"FAC_QTRS_WITH_NC\", ascending=False)\n",
-    "num_noncompliant = noncompliant.shape[0]\n",
-    "plt.pie([num_noncompliant, num_facilities - num_noncompliant], labels=[\"Noncompliant\", \"Compliant\"], autopct='%1.1f%%', shadow=True)\n",
-    "\n",
-    "plt.title(\"%s of %s Total Facilities Noncompliant in %s in the last 12 qtrs\" %(num_noncompliant, num_facilities, my_zip))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Where are these noncompliant facilities?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "map_of_noncompliant_facilities = mapper(noncompliant)\n",
-    "map_of_noncompliant_facilities"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Which facilities are out of compliance?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Which facilities aren't in compliance?\n",
-    "\n",
-    "print(\"Facilities in %s noncompliant in the last 12 quarters:\" %my_zip)\n",
-    "cols_for_print = [\"FAC_NAME\", \"FAC_QTRS_WITH_NC\"]\n",
-    "print(noncompliant[cols_for_print])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# More details on noncompliant facilities\n",
-    "print(\"Facilities in %s noncompliant in the last 12 quarters:\" %my_zip)\n",
-    "\n",
-    "additional_cols = [\"FAC_3YR_COMPLIANCE_HISTORY\", \"FAC_INSPECTION_COUNT\"]\n",
-    "cols_for_print.extend(additional_cols)\n",
-    "cols_for_print.extend(permit_cols)\n",
-    "\n",
-    "print(noncompliant[cols_for_print])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Greenhouse Gases"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0.5, 1.0, 'Of the 4012 facilities reporting to ECHO in Minneapolis, 9 report greenhouse gas emissions.')"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjgAAAD3CAYAAAAQVC6+AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nO3deXxdVbn/8c9zhqRt2qalLaUt0MoUyliZURQQEQUNyCAoKqAgqFccfuq9VxwConLV6wgCosgoyqQExQuiMpZ5HiNDC6UDbSlN5+QMz++PtUJOT0+mNu1OTr7v1yuvnLPHZ++z99rPXmvtc8zdEREREakmqaQDEBEREelvSnBERESk6ijBERERkaqjBEdERESqjhIcERERqTpKcERERKTq9EuCY8HvzOxNM3uwl/NcZmbn9sf6BwozG25mN5tZq5ldtwHLOdHMbit572a2XXx9kZl9q5t5v2Fmv1nfdQ8WQ2U7+5OZrTCzbTbyOp4xs4M25jo2JjNrMrOr4uut4z5LJx2XVGZmJ5vZPUnHUU3M7G9mdtIGzN/tNWpT6lWCEw+ip8xslZktMLMLzWxMySQHAIcCW7r7Pl3Mv9EPQjPbzMwWla/LzA4xs+dj/P8ys6kl4z5iZjPjuDvK5tvBzG6Ky1xiZreaWUM3IRwLTATGuftx67sd7n61u7+vi3FnuPt3Y3wHmdlrZeO/7+6nru+6B6JNvZ2lCeV6zDstzr+i7O/4kmn2MbNbzGxpPK4eNLNT4rh1tjUOv8PMTi15PyaehwvisftUxzK64u4j3f3lDdimR8uGjzezdjObXbKOnd39jr6uYyBy91fjPitsyHLMbEosR5aY2WtmdkZ/xbgxbMjxL4Ofu3/A3S/fgPnfukYlrccEx8z+H/A/wNeAemA/YCrwdzOriZNNBWa7+8qNFWgv/Q/wXOkAMxsP3Ah8C9gMeBj4Y8kkS4CfAedVWN4YoBloICQuDwI3dbP+qcC/3T2/nvEPCmaWqcZ19bMx8eLY8fdHADPbH/gncCewHTAO+Czwgd4uOJ53txOOt/0J5+XXgPPM7Cv9uxlrqTOzXUrefwyYtRHXVy2uIuynicARwPfN7ODezDjYz7VYu6+uEJIMd+/yDxgNrAA+UjZ8JLAQ+BTwaWANUIjTnl027fSy8Uvj8MuAC4C/AsuBB4BtS+bbEfg7IQFpKY+hQqz7A/cBpwD3lAz/DDCz5H0dsBrYsWz+U4E7eljHZoATamjKx50NtAO5uJ2fBrYlXMzeABYDVxMufB3zbEVIvhbFac6Pw08u2wYHtivZb+eWbEcxrm8FMBloAq4qmXc/YCawFHgCOKhk3MnAy3H/zwJO7GK7m4DrCQX1srivUsB/AS/F2K8FNovTT4sxfwaYB8wH/l/J8moJSeW8+PczoDaOOwh4DfhPYAFwXU/bWbK+k4BX474+q2R9w4HLgTcJCfDXgde62Na74rJWxnUdH4efBrxIOB6bgcldzN8RS6aL8fcAF3RzjB1UKTbgDuDU+PrThPOvrmya42PMo7tYdvlx1OX518U2fRP4Ucnwh4GzCDc3HcNmA+8tOW6uBa6I63gG2Kts2q8CTwKthBuPYSXjPwg8Tjh2ZwK7lYzrOPaWA88CHy47ru8FfhmX+zxwSMn4yfEzXBI/09PKjvXy4yrTl/OlQlnpwISSYb8Gruzu86fz+L+yF/tiNvDfcT+8CfyubD92eezG2D4PvBC3qeLxXxZjGvhfwnk2C/iPsv10B/C9+BmsJiTy9cBvCWXBXEIZli5Z5qcI5+abwK3A1LIYz4gxvkk4bq20rAR+HMfNAj7Qy8/6MuDcrs69+BnMjZ93S8cxRDdlXxef6dfjds8jlJ2l5+ERwGOEcnUO0FQy3zBCmftG/NwfAiZ2sY7JwA2Ea8ks4MyyY/q6uKzlwFPADvGYWRjX+74uyprtCDdjrfHz/mMcbsBP4/ythHN4ly72a0/HX1efbcV19+Wvp5Pz/UCeCoU14YJxTelB1s1y1hkfd8ISYB8gQ7j4/yGOq4s7/ZQ4bo+4gTt3sfw08CiwZ/m6gJ8DF5ZN/zRwTNmw3iQ4RwHzuxnfxNrJxXaEprtaYAKh8PhZScxPxIOkjnAwH1Bpf1Ehwal0QpbHAEwhnByHE07KQ+P7CXGdy4CGOO2kbvZvEyFxOyouZzjwJeB+YMu4fReXHA/TYszXxPXsSjjxOi5858R5N4+xzAS+W7JNeUJtXG1cV0/b2bG+S+L0uwNtwPQ4/jzCiTI2xvtk+fLKlv3W/o7v30M4/vaIMf0SuKuLeTtiqXTOjCAk+gd3s+51trVCofMH4PIK02Tivjusp+2im/Ovm22aRjgv04QblxbgvXSf4KwhHH9p4AfA/WXTPkgonDcjXODOiOP2IBSe+8Z5T4rTdyTCx8X5UoTEbiUwqeT8yQNfBrJxfCudCfidwK8I59wMwrF5SEnM6yQ49OF8Kdt3o+IyNi8ZdgnwWDeff/nx39O+mE0o07aK+/FeOsuIbo/dGNvf43zDKx3/FWI8g5BMbUk4p25n3QTnVWDnuO+ywJ8JZUQd4bx/EDi9pFx9kXBMZQiJ9MyyGP9CqFHfOn5e7y/5rHOEi2iaUBs6j86LZHef9WV0keAQau3nEC/G8VjYNr7usuyrsK/eT0hUdyac/1ey9nl4EKF8TAG7Aa8DR8VxpwM3x/nShOvbOjcvcd5HgG8DNcA2hET8sLLz8LC4f68gJEFnxc/mNGBWF2XNNXG6FGtfow6L6xxDSHam03n+vbVf6d3x19VnW3HdffnrqepwPLDYKze5zI/jN8SN7v5gXP7VhAMQwt3KbHf/nbvn3f1RQnZ6bBfLORN4wN0fqTBuJKFwK9VKKHh6zcy2JGSXvW4CcPcX3f3v7t7m7ouAnwAHxtH7EAror7n7Sndf4+793U/p48At7n6Luxfd/e+Eu+7D4/gisIuZDXf3+e7+TDfLus/d/xyXs5pw8p3l7q+5exvhJDq2rJr77LhtTxHuKj8ah58InOPuC+N+ORv4RMl8ReA7cb+t7sP2nu3uq939CULyuHsc/hHg++7+pru/BvyiD8vsiPdSd380but/A/ub2bRu5lkc+9h0/E0nXAxShHOnO5PL5l1K6OfWYXylZcTzaDG9Py+7Ov+68hqdSc1JhIKyJ/fE469AKNx3Lxv/C3ef5+5LCIV5RwynARe7+wPuXvDQJ6CNUCOJu18X5yt6aP57gXBOdVhIuJnIxfEtwBFmthVhX/5nPOceB37D2sdfV/pyvhDjXE5IOL5lZsPMbA/gGMJFq7v1lB7/3e6L6Hx3nxP34/dY+1zr6dj9gbsv6cO59hHg5/Hcf5PKzfuXufsz8djajNAE+6VYHiwk3NidEKc9PcbwXJz++8CM0r6SwHnuvtTdXwX+xdrH6ivufkk8xi4nJJ8TN/CzLhAuyDuZWdbdZ7v7SyXx9lT2le6r38V9sYpQ1r3F3e9w96ficfwk4aLecY3IEZqwt4uf+yPuvqzCOvYm1BCe4+7tHvrZXULn/gW4291vjfv3OsKN5XnuniPcME0r61fbIUdoCp9cdo3KEa6hOxKSyefcvVK51pvjr6vPtqt191pPCc5iYHwXH9ykOH5DLCh5vYqQjEDYqH3LCvgTgS3KF2BmkwkJzlldrGMFoamt1GhCVV2vmNkE4DbgV+5+TR/m29zM/mBmc81sGaGKsOPisxXhxNyY/XWmAsdVuFBO8tBf6njC3dh8M/urme3YzbLmVFj2n0qW+xyhUJjYxTyvEBI64v9XuhgHsMjd1/RuE9fS1fE0uSyW8m3pyVrxuvsKQk3YlG7mGe/uY0r+Oqrfi4RzpzvzyuYdQ6iG77C40jLieTqe3p+XXe2v7lxBuGv+KOF47us6hpWVJ92VAf+v7NjdinicmNknzezxknG7sHZiN9c93AZGHcfYZGBJTDxKx3X3WbIe50upE4G3EY67CwnJ5DodyUuUH//d7ouoV+daF8fu+pwPPZ1PpcOmEmoK5pfEfzGhJqdj/M9Lxi0h1AqUxtjdsfrWuJhEEMev12cdl/MioaamCVgYy/GOfdqbsq9Dt/vKzPa18ODLIjNrJRxfHcfxlYTmuj+Y2Twz+6GZZSusYyplN0XAN8rieb3k9WpCxUWh5D1UPv+/TvgsHrTwhOSnANz9n8D5hJv+183s12ZWfp3t2P6ejr+uPtuK6+6LnhKc+wh3CkeXDjSzOkJG/o9ersd7nmQtc4A7ywr5ke7+2QrT7kMo7J81swWEJql94tMlaUK7/1t3jTH2bePwHpnZWEJy0+zu3+vjdvyAsO27uftoQo2KlWzj1hvYsa+n/TqH0IZfuh/r3P08gJjRH0rYf88Tsv7ermsOoa27dNnD3H1uyTRblbzemlB1TPw/tYtxldbV1+On3HxCdXKluHpjrXjjMTSO0D7fa7HwvY9wB78hbgc+EOModQzhfL1/A5ffnRsI/QZedvdXepp4A8wBvld2fI1w92vinf0lhL4f42IC+DSd5xbAFDMrfd9xjM0DNjOzUWXjevws+3i+lM73irt/0N0nuPu+hGOnu6/TqHSuVdwXJdP06lzr4tjt6/nVm/OpdJlzCMdladI/2t13Lhl/etn2DXf3mX2Mq1xPn/VK1q5JW+sG2t1/7+4HEPafE5oNO+Ltqezr0NO++j2hX8pW7l4PXEQ8jj3UPp7t7jsB7yC0bHyywjrmEJqYSuMZ5e6HV5i2T9x9gbuf5u6TCTVXv+p4ws7df+HuexKa33YgPOhQbr3Lzu7W3VvdJjju3kqoUvulmb3fzLKxauk6wh3Ilb1cz+vAliVPXfXkL8AOZvaJuM6sme0dq/nL/Y3QPjoj/n2b0GlrRsxQ/0SoVj7GzIbF8U+6+/MAZpaOwzNAKlYjZ+O40YQM+l53/69exl5qFLFjtZlNYe0D4EHCwX+emdXF9b6zj8t/HRhnZvVdjL8K+JCZHdaxnRYeQ97SzCaaWWM84NpinH15HPYi4Hsd1chmNsHMjiyb5ltmNsLMdib0p+p4eu0a4JtxnvGEz6S72oCetrMn1wL/bWZj4+fwHz1M/zqhHbvD74FTzGyGmdUSqtAfcPfZ6xHL14GTzexrZjYOwMx2N7M/9GEZVxLOv+ssPMKdNbPDCE1vTfG83ShiTcZ7CH3WNqZLgDPiHa7Fc+SIeLGqI1xwFgFYeDx+l7L5NwfOjPvmOEIfgVvcfQ6hz9cP4vmwG6HT9tXdBdPd+WKdj9FP62Le6WY2ysxqzOzjwPsIzdX9sS86fD6e15sR7t47zrX1OXbLj/9y1wJftPD4+xhCZ9wuxaaL24D/NbPRZpYys23NrKMp5iLC+bkzgJnVx89sg/Tis34cONzC14tsQaixIcbQYGbviftsDaGWo6N87E3Z1+Fawv6fbmYjCGVdqVGEWqY1ZrYP4cnEjhgONrNd4436MkKTTaUy+kFgmZn9p4XvYkub2S5mtnevdlQ3zOw4C90zINRAO1CI1+N947VyJZ0PEpVb77Kzq3X3Jf4eH99z9x8STpgfE3byA4SM8ZDYptYb/yTUmCwwsx6rz2OV4vsIbYjzCFVYHZ3uyqdti5neAndfQOhfk4uv8dDH4xhCu/SbhI56pW2TnyAcvBcC74qvO+7MPkxo3zzF1v5Ok617ud1nEzpXtRKeVrmxJO4C8CFCR+RXCRes4ysso0sxSbsGeNlC1eTksvFzgCMJn98iwuf2NcLnngL+H2H/LiG0+36uD6v/OeHO4zYzW06oNdi3bJo7CZ0H/wH82N07vrzwXEJfoCcJPfofjcPWazt74RzC/p1FqP24nnCR6koTcHlc10fc/R+Erxm4gZCUbsvax1AlS8uOma/EbZlJSBDeE7dnCeGpmlt6uzHxvHsv4fN8gHBe/oTQL+BHvV3O+nL3h72zP8JGWweh78n5hPP2RULTGO7+LOEpnvsIF+NdCf1cSj0AbE9orvsecKy7vxHHfZRwUzSPcAP0HQ/907rT3fmyFaEavqu70sMInT7fJDRBvD+WS73S3b4o8XtCEvFy/Ds3zrs+x24TJcd/hfGXxHU9SbiZvIXQMbq7i88nCR1gO570up7YzOrufyKU73+w0JT/NH342oQedPdZX0noqzc7bk/p14fUEvoWLSZcfzYnlKPQu7IPAHf/G+HG41+Ez+2+OKqj/PkccE5czrcJCVGHLQj7aRmhGexOKtwIllxLZhDKuMWEvkbre0NYam/gATNbQdjmL7r7LEI3j0sIn+UrhGanH1eIbX2Ov57W3fGFoif2tICOnuYi/Sbeyc4Csj4AvxPIzD4LnODuB/Y4sQw6ZnYy4SmQA3qatp/W901Cv5mLN8X6Kqx/NmF7b09o/R8ALnL3qT1OPMRZaIV4mvAE3IArG6uNvoBJqp6ZTTKzd8aq8QbCnfifko5LqoO7n5tUcpOE2AxyuJllLDT5fgedT10ysw/H5smxhJqqm5XcbBpKcGQoqCE8tbGc0Fx6E+G7MUSk74zQ/P4moYnqOdbtWyKdTid0EXiJ0IxX6WEZ2QjURCUiIiJVRzU4IiIiUnWU4IiIiEjVUYIjIiIiVUcJjoiIiFQdJTgiIiJSdZTgiIiISNVRgiMiIiJVRwmOiIiIVB0lOCIiIlJ1lOCIiIhI1VGCIyIiIlVHCY6IiIhUHSU4IiIiUnWU4IiIiEjVUYIjIiIiVUcJjoiIiFQdJTgiIiJSdZTgiIiISNVRgiMiIiJVRwmOiIiIVB0lOCIiIlJ1lOCIiIhI1VGCIyIiIlUnk3QAIjJINdUbMAHYssLfFKAeqAFq418a8PhXBNqBxcDrwMIK/xcAs2hqzW2ybRKRqmHunnQMIjLQNdWPAvYC9gH2BmYQEpnajbzmduA54PG1/ppal27k9YrIIKcER0TW1lSfAd5OSGb2cfe9gQYzG0hN2q8Qkp37gL/R1PpkwvGIyACjBEdEoKl+BHCYux8FfMjMxiYdUh/NAf4G3ALcTlPryoTjEZGEKcERGaqa6scBHyoU/WgzDk2ZDUs6pH7SBtwF/BVopql1VsLxiEgClOCIDCVN9XXARwtF/2TKeIeZpZMOaSNzQrLzO+A6mlpXJRyPiGwiSnBEhoKm+l3b8v6FTIqPpVNWl3Q4CVkOXANcoD47ItVPCY5ItWqqt6L7h9ryfGN41vZNOpwB5m7gAuAGmlrzSQcjIv1PCY5ItWmqr12T988YfLU2Y1snHc4A9wpwNnAFTa2FpIMRkf6jBEekWjTV25LV/pm6LN+tzdiEpMMZZFqA7wDX0tSqQlGkCijBEakCC782qnF4xn4+qtamJR3LIPcE8C2aWm9OOhAR2TBKcEQGscVfH7VX2uyiscNtz6RjqTL3A2fR1PrPpAMRkfWjBEdkEGr9r9FTc0X/1WbD7QMpM0s6nir2R+ALNLUuSjoQEembgfTV6yLSg8aGrL145qhvDs/y7/EjUocrudnojgeeo6n+xKQDEZG+UQ2OyCBx+yfrdpw+PnXDlNGpnZKOZYj6K3AGTa2vJR2IiPRMCY7IANfYkLWmg2q/sdOE1LeGZWxj/3q3dG8Z8HXg13raSmRgU4IjMoDd9om6aQ3jUtdPHZNSJ+KB5Q7gkzS1zkk6EBGpTAmOyADU2JC1b7yr5ozdJqZ/PCJrI5KORypaCBxHU+tdSQciIutSgiMywDQ2ZOvOelfN7/aekj5WnYgHvDzwFZpaf5l0ICKyNiU4IgPIl/armXrqHjU377J5etekY5E+uYzQAbkt6UBEJFCCIzJA/PDQYe/46C7ZG7aqT22RdCyyXh4CjtZTViIDgxIckYQ1NmStsSFz8rE7ZX8xZpiNTDoe2SALgWNpar076UBEhjolOCIJamzIZk/aPfuDD+6QObM2Y9mk45F+0QacQFPrn5MORGQoU4IjkpDGhuyo0/bIXnLEDpmPqDNx1ckDp9DUelXSgYgMVfqpBpEENDZkJ5wyI/vHD+6QOV7JTVXKAFfQVP/ZpAMRGapUgyOyiTU2ZDc/ZUb26qN2zLxXuc2Q8B80tV6QdBAiQ41qcEQ2ocaG7BYn7a7kZog5n6b6zyUdhMhQowRHZBNpbMhu8ZGdM5d+eHrmECU3Q875NNWfkXQQIkOJmqhENoHGhuz4Ixsyvzl5RvZD6ZTpxmJoKhK+J+empAMRGQpU0IpsZI0N2bHvnpr+6Ukzsh9UcjOkpYCraaqfkXQgIkOBCluRjaixITty2hj7zmf3qjk6k7J00vFI4uqAZprq9W3VIhuZEhyRjaSxIZsZkeWM/zqg9mN1NfpFcHnLVsBNNNUPTzoQkWqmBEdkI2hsyBpw5NffWXv65FGpCUnHIwPOPsBlNNWrt7nIRqIER2Tj2OvkGdmv7zEpvV3SgciA9RHg7KSDEKlWSnBE+lljQ3bqu6emm47aMbNX0rHIgPctmuqPTjoIkWqkBEekHzU2ZOu3GWtnfX7vmoNTpiempFcuVqdjkf6nAliknzQ2ZLMGp39pv9ojhmdNHUilt8YDlyQdhEi1UYIj0n8aT9wte9S0ManJSQcig84Haao/NekgRKqJEhyRftDYkN1m63r7yFE7ZvZIOhYZtH5CU/20pIMQqRZKcEQ2UGNDtgb49Ff2r923Jm21Sccjg9Yo4HKa6lUui/QDnUgiG+4DH9k5865txqamJh2IDHrvBr6cdBAi1UAJjsgGaGzIbj1ppH30uJ2yeycdi1SN79FUr+9PEtlASnBE1lNjQzYLfPor+9fsXZuxYUnHI1WjFjgv6SBEBjslOCLr79D3vC29X8P49DZJByJV5xia6t+RdBAig5kSHJH10NiQ3QI45mO7ZndNOhapWj9OOgCRwUwJjsj6OfJDO2S23LwuNSnpQKRq7U9T/TFJByEyWCnBEemjxobs1ilj/2N3yr496Vik6p1HU3026SBEBiMlOCJ90NiQNeDo43bKbDV2uE1IOh6petsBn006CJHBSAmOSN9sm02xR2NDVt9YLJvKt2mqr086CJHBRgmOSC/F2pvjPr5bduqoWhuTdDwyZIwDzkg6CJHBRgmOSO9Nr0kz/bDtMup7I5vaF9QXR6RvlOCI9EJjQzYFHH/09MzEEVkblXQ8MuRMAU5IOgiRwUQJjkjvTAemvnebzM5JByJD1leSDkBkMFGCI9I779tvy3Td5nWpKUkHIkPWDJrq35l0ECKDhRIckR7Eby3e7agdM9snHYsMeXpkXKSXlOCI9Oxd9bWkdhiX2inpQGTIO5am+vFJByEyGCjBEelGY0O2FnjPcTtnN8+kTE+xSNJqgVOSDkJkMFCCI9K9XYDa/bdM75Z0ICLR8UkHIDIYKMER6d4hO09I1UyoS01OOhCRaE+a6rdOOgiRgU4JjkgXGhuymwPT37tNZmLSsYiU+XDSAYgMdEpwRLq2K+A7TUjtkHQgImWOTjoAkYFOCY5I1/YfN9zaJo60rZIORKTMATTV69fsRbqhBEekgsaG7Chgm/dvl9k8ZWZJxyNSJgUcmXQQIgOZEhyRyrYHmLFFSl/uJwOV+uGIdEMJjkhle6aN9qljUtslHYhIFw6hqV4//CrSBSU4ImUaG7IZYM93T00PH5ax4UnHI9KFWmC/pIMQGaiU4IisaxpQs9+W6bclHYhID/ZNOgCRgUoJjsi6dgKKW47WL4fLgLdP0gGIDFRKcETWtRewdEKdbZF0ICI9UIIj0gUlOCIlGhuyWWDKNmMtNSxjI5KOR6QHE2mqn5p0ECIDkRIckbVNBJixRVq1NzJYqBZHpAIlOCJrmwTYtmNTk5IORKSX1NFYpAIlOCJrmwoUpoxOqQZHBgvV4IhUoARHZG0NwIoJI9TBWAaNXZMOQGQgUoIjEjU2ZNPA1AkjLD+q1sYkHY9IL42hqX5k0kGIDDRKcEQ6jQfSO4xLjU46EJE+0i/ei5RRgiPSaSLAhDrT3bAMNkpwRMoowRHpNBqwzYYrwZFBRwmOSBklOCKdxgA+ZpjVJR2ISB8pwREpowRHpNM4oH10rWpwZNBRgiNSRgmOSKfNgPZRNSjBkcFGCY5IGSU4Ip02A9rratREJYOOfvlepIwSHJFOY4D2EVk1Ucmg0+uk3MwKZva4mT1tZjebbfzvfDKzk81scsn735jZTv207Ilm9nsze9nMHjGz+8zsw3HcQWb2l7LpLzOzY+PrjJl938xeiPvkcTM7q4v1zDazp0qm+0Uf45y5Htt2jpm9t6/zSaAER4S3vuRvJJAflqHff0X85/e3scuvVrDzr1bws/vbAHhiQYH9f7uSXS9cwYeuWcWyNq8470/va2PnX61gl1+t4KM3rGJNPkx34o2r2O3CFXzjH2vemva7d7Zx0/O5/g5/SPm/F/M0nL+C7X6xnPPuaVtn/E/ua2OnC1aw24UrOOSKlbyytAhAy+ICe/56BbtftIL75uQByBed916xklW5yp9tPxrWh2lXu/sMd98FWAJ8fiPFBICZpYGTgbcSHHc/1d2f7YdlG/Bn4C5338bd9wROALbs5SLOjXHt6u4zgHcB2W6mPzjuuxnufmZfYnX3d/Rl+jjPt9399r7OJ8GgSHDMzM3sf0vef9XMmnqY56iu7hDMrMnM5sYs/Fkz+2g/h1xpndPM7GMl7/fq6x1AD8v/uJk9aWbPmNkT8Q5pTBx3h5ntVRbL0yXv94nTvGBmj5rZX81sna9/j3dhi0ruYB7vy12YmZ1hZp/s43ZNNrPr+zLPeqoDHHDr5/Pi6YUFLnk0x4On1fHEGXX85d95XnijwKk3r+a8Q2p56rMj+fCOGX5077oX07nLivziwXYePq2Opz83kkIR/vB0jidfLwDw5GdHcverBVrXOPOXF3lwXoEjd+yufJbuFIrO529Zzd9OHMGznx/JNU/neHZRYa1p3r5Fmoc/U8eTnx3JsdOzfP32kGBe/EiO8w4ZxvXHDefH97UDcOFDOT6xW5YRWdvYofclwSl1HyXNW2b2NTN7KJYlZ8dh08zseTO7PA6/3sxGxHGHmNljsWbjUjOrjcNnm9m3zewe4KPAXsDVscwYXlommdkKM/teLLfuN7OJcfi28f1DsSZjRYX43wO0u/tFHQPc/RV3/2VPGx634TTgC+6+Js673N2b+rID47b81MzuMhJOk1IAAB0FSURBVLPnzGxvM7sxlqfnlky3Iv6fFKftqEV7l5mlY83S03FffjlOW1rb1N2+PjuW3U+Z2Y5x+IEl5fRjZjaqL9tVDQZFggO0AUeb2fg+zHMU0N3F96cxYz8SuNjMNtpVwcwywDTgrQTH3R/u6x1AN8t/P/Bl4APuvjOwBzCT+MV1Pcw7EbgW+Ia7b+/uewA/ALbtYpY/ltzBzOjLXZi7X+TuV/R2+jjPPHc/ti/zrKdaQoKDGf16NXpuUZH9tkwzImtkUsaBUzP86fk8LYuLvHtqGoBDt8lww3P5ivPni7A6H2oDVuVg8qgU2RSszkHRnfaCk07Bt//VxjkH1fZn6EPOg3MLbLdZim3GpqhJGyfsnOWm59f+XA5+W+athGW/LdO8tizUzmRTsDofPqNsCpaucW7+d45P7r5hRUvR3QtFL+SK5NoLtK/Js2Z1nlUrc7ZyWbutWp5LLW33zMK+LjfWrBwCNMf37wO2J/x45wxgTzN7d5y8Afi1u+8GLAM+Z2bDgMuA4919VyADfLZkFWvc/QB3vwp4GDgxlhmry0KpA+53992BuwhJB8DPgZ+7+97AvC42Y2fg0R429V2lN2VAYxy+HfCquy/vYf5S/ypZ1pdLhre7+7uBi4CbCLViuwAnm9m4smV8DLg1Xn92Bx4n7O8p7r5L3Je/K52hF/t6cSy7LwS+God9Ffh8Sc1U+X6vepmkA+ilPPBrwkV8rfZRM5sKXApMABYBpxCqJxuBA83sm8Ax7v5SpQW7+wtmtgoYCyw0s22BC+LyVgGnufvzZnYZsIZwQk0EvuLuf4kH3oWEO5R8HP4vMzsZOIJwZ1UHjACmxxPscuAx4Kvu/kELtVFbA9vE/z9z91/E7fsWcCIwB1gMPOLuPy7bjLPisubGbSrEfdIb/wFc7u5vtQ+7+z29nJcY40HA2cDrhBP1RuAp4IvAcOAod38pbucKd/+xmZ0JnEHYZ8+6+wlmdiChUIOQbLyb8Oj2X9x9lx72dSNhH28L/Mndvx4L8N/G6R241N1/2sVmpOhIcPo58d9l8xRn/bPAG6uKDM8at7yYZ69JKXbZPE1zS54jd8xy3bM55iwrrjPvlNEpvrp/DVv/dDnDs8b7tk3zvm3Dabt1fYo9Ll7JJ3bL8uKSIg68fVK6P0PfZIru7k6xiBXdKRYdL0LR3bwIXnQrxv/xtXnBzYuYF928QHgdhqUoeMoLmMf/FEh5wVPhPynynvICaQqkyJPuGMadc5fUrcgsHX7Z0p0WF0jzrM0f+dKC5bUjlu6+JE+aAmnLkyZP2vJkaL73gbHDt6grfmXp3suX7LAqc/qt/xybLxTtHe89qnW//3t2xJQZO7adsHy7fJw+/Fk6VSBjedKWt4zlyaQKlrY8mVSetBUsk4rDUgXLGmBAOv5VMoICo2b3fncPj+XQNOAR4O9x+Pvi32Px/UhCwvMqMMfd743DrwLOjPPNcvd/x+GXEy7sP4vv/9jLeNqBjn4yjwCHxtf7E25UAX4PlJd76zCzC4ADCAnH3nHw3e7+wZJpLuti3lMIZdY44B3uPqfCZAe7++IKw5vj/6eAZ9x9flzmy4Qn3N4omfYh4NJ4U/1nd388TreNmf0S+CtwW9nyG+h+X98Y/z8CHB1f3wv8xMyuBm5099cqbXc1GywJDoSk40kz+2HZ8POBK9z9cjP7FPALdz/KzJoJF8ZumzfMbA/gBXfvuAP6NXBGTHz2BX5FqAaFUCAcSLiI/svMtiO2X7v7rrFq8DYz2yFOvz+wm7sviUnAVztOtPi+1I7AwcAooMXMLiRk98cAbyd8Vo8SDuByvbmLudrMOjL4GqDjaroz4WTprePN7ICS9/vH/7sD0wlt+i8Dv3H3fczsi8AXgC+VLee/gLe5e5t1dnLsuOO418xGEhLKUt3t6xmE/dRG2H+/BDYn3hUBWPedKd+qtbF+bk2YPiHNf76zhkOvXMXIGmP3iSkyKePSI4dx5t/WcM5dbTTukKUmve6K31zt3NSSZ9YXRzJmmHHcdau56sl2Pr5bDT97f2erxIeuWcXFHxzG9+5q44nXCxy6TYbT9qzp3w3pB+5O0Sl6RyIDXnSKVKg0s9g6nQIw703m1uUn5+Xju+gSs3p4Lr2sNp86ru6xyQCF4e2pEcMKqVPr7i6tGjOA3z/Vnsq+mUv95YgR+drMrOHUEW6vgJeW/Ln+nPa29A+3fKHmrNva0l5wmg6sLWw/Lv3WutcNYZ3w1814153PMinah6VphaWVN6rCZrr7DDOrJyQWnwd+EQP4gbtfvNYKzKZVCNcrBVxmZS/jybl7x/IL9O269AyhjAxBuX8+1vQ/3It5XwS2NrNRsWnqd8DvLDTf9/VOoaN9uVjyuuP9Wtvj7nfFmrEjgCvN7EfufoWZ7Q4cRvg8PgJ8qmS2nvZ1xzrf2n/ufp6Z/RU4HLjfzN7r7s/3cbsGtUGT4Lj7MjO7gnDnUFrVtj+dGeuVQHkC1JUvm9lphFqT9wPEi+o7gOus8ypXWrBd6+5F4IWYce9IuFv4ZYzxeTN7Bei46P7d3Zf0Mp6/unsb0GZmCwm1RAcAN3VU6ZrZzT0txELfmSsJidI33L3jLupEd384TjONzjum8vkfIPxkwW3u/sUKk/zR3f+jbB6Ah0ruWl6i8w7kKULiVu5JQtL1Z0InQahwx2FrZxvd7et/uHtrXP+zwFRC4dfdXdFam9HxouhdXf7W36f3qOHTe4SE4xv/WMOWo1PsOD7NbZ8ID7/8+40Cf31h3c7Bt7+c521jUkyoC5VKR0/PMHNOgY/v1jnNTc/n2GtSmpXtztOLClx73Aje/buVnLhp+n70iZmRNlIM0Obx7Tczrn6qSF2WGoA3VjnT6lNvve9w+8t5fnJfO3eePIJxw9dt3v7+3W2cd0gtlz7anjp5RpZpY4zv3tWWufro7vqvr/dhN2x9Znb31liTelO8oboV+K6ZXe3uK8xsCtBxUG5tZvu7+32EPjX3AM8D08xsO3d/EfgEcGcXq1tOKJP64n5C8vJHQsfhSv4JfN/MPuvuF8ZhvXpIwN1XmdlvgfPN7HR3XxNrfTfqnUFsdZjr7peYWR2wh5ndQqh1uiGWn5eVzdaXfd2xnm3d/SngKTPbn3C9GlIJzoAsZLrxM+DTdP9IZG9P9J+6ewNwPHBFbP5IAUvL+phM72bZPd3F9PYOBtbO+juy8N5enZ4h9LvB3Z+Kba5/IzQP9XreOP++wLeA+l6uu0P5XUvpHU2lRPoIQq3cnsAjZpZx9/OAU2Pc93d0livR3f5YZ/+5+5uEmqU7CHdFv+nNhhSdyp1hNsDCleFm/NXWIjc+l+eju2TfGlZ059y72jljr3XL1a3rjfvnFliVc9ydf8wqMH18581lruD8/IF2vvbOGlblOndQ0aG9sM7ipAd7T0nzwhtFZr1ZpL3g/OGZHI0Nax++j80vcPpfVtN8wnA2r1u3CL1zdp4po1JsPy7NqhykDNIGqzbuw23rdcy6+2PAE8AJ7n4boSnoPjN7CriezqTkOeAkM3uS8H1RF3romHsK4YbwKcK5flH5OqLLgIti35XelEsQan2/YmYPApOA1grxO6EZ60AzmxWnvRz4z16u4yxgPvC0mT0G3B3n76rPT2kfnD71JyxxEPB4XN8xhGb5KcAdsenwMuC/S2fo477u8CULnZafIFQK/G094x20Bk0NDkBs6rmWkOR09DGZScjuryT0VenoP9KrOwZ3v9HMTgJOcveL40lynLtfZ6H6YDd3fyJOfpyZXQ68jVDz00LoFHci8M/YXLJ1HL5H2arW5w7mHkIH6B8QPqsjgEsqTPcD4MdmdmRJO2tvC5ELgAfM7NaSfjj9/ph0KTNLAVvF/jP3EDrdjTSzcRXuOB4vmbW3+7pjPePp/q6o1FvNAUWn31ODY65dzRurnGwaLjh8GGOHGz+/v50LHgpXvaOnZzhlRqgImLe8yKnNa7jlxBHsu2WGY6dn2OPilWRSoY/NZ/bsrDC44KF2Tto91NTsNjGFA7teuILDt8swZtjAqr0ZDDIp4/zDh3HYVasouPOpGTXsvHmab/9rDXtNTtPYkOVrf1/DinY47rpQkbx1fYrmj4ZTxt059+42rj02vP/MnllOvHE1+SJceMT6PujUK71OcNx9ZNn7D5W8/jmd/eCAt2p8i+5+RoVl/YPQNFw+fFrZ+xuAG0oGHVQpntiloKNbwVxgP3d3MzuBLpqdYs1xxRoed7+DcINTOuzkktc5QnP5f1Wav2y+aV0MP6ir9ZWNGxn/X07lbgHrlGNlsfa4r2Mt/UHx9RcqbsgQMqgSnOh/CR1jO5xJ6LD1NTo7GQP8AbgkVsEe6110Mo7OAX5vZpcQLqAXWuicnI3L6UhwWgjVghMJ/XTWmNmvCHcmTxEKmZNjv5LydTwJ5GM2fRmdHfm65O4Pxb5ETwCvEE7wSncxt5jZBOBvsYp1KfA0ocq5p3UsMLPjgf+JVdILCZ2Zz+lilvI+OJ/raR0VpIGrYh8AI9SmLTWz75rZwYQamGcJdxyTSubr7b7uMIXQpt5xm/3fXU0Y12kAhWL/Jzh3n7JupeMX96vli/ut+9TT5FEpbjmxM8c8++BhnF2pkQ/4Usn8ZsY1x2zU3HRIOHz7LIdvv3ar0zkHdyYnt3+y6wpkM+Pvn+gcP31CmkdP3yTfG1mNT8jsSWg+MkKZ9qkephdZi3X27ZLuWOh532On5Y2w3pGxPXwEoQbjM+7eU4di6aPGhuxYwlMacy49ctjp40ektkg6JpE+eJSm1j2TDkJkIBlsfXCGol/HdtlHgRuU3Gw0b9XarGhnWZKBiKyH+UkHIDLQDMYmqkSUtoVu4vV+rOeppB+sIjZRLWvr0xd/iQwESnBEyqgGRwRobsnlgRVAzdI1rhocGWyU4IiUUYIj0ukNoHbJatXgyKCjBEekjBIckU6LgZpFK1WDI4OOEhyRMkpwRDotBGrnryiqBkcGm66+mE5kyFKCI9JpEZB9tVU1ODLoqAZHpIwSHJFOy4DiwpW+pr3gbT1OLTIwLAOG3C9Fi/RECY5Ip+XE3xtbvMoXJByLSG89RlOrvrFVpIwSHJFOS4jnxNxlPjfhWER665GkAxAZiJTgiHRaAqwBsi8uKarTpgwWSnBEKlCCIxI1t+QceAEY9fiCghIcGSyU4IhUoARHZG3PAXXPLS6+uSbv1fgLzVJF3H058O+k4xAZiJTgiKzt1Y4XC1e6anFkQDOzx9XBWKQyJTgia3srqZm7TP1wZMBT85RIF5TgiKytFVgJ1P77jaKepJKB7p6kAxAZqJTgiJSIHY1bgFH/nJWfVSh6IemYRCpx93bgtqTjEBmolOCIrOs5YMSba2ifu9xnJR2MSCVF5y6aWvW7aSJdUIIjsq6WjhdPvl5o6W5CkaSkU/bnpGMQGciU4Iisax7wJjDi1hfzz7vrIRUZkG5OOgCRgUwJjkiZ2A9nJjD2lVZfsWiVfrZBBpZC0Z+mqfXVnqcUGbqU4IhU9gSQBnh2UVHNVDKgqHlKpGdKcEQqm034XaqaO2bnn082FJF1qHlKpAdKcEQqaG7J5YEHgHGPzi8ual3jS5KOSQSgUPS5wENJxyEy0CnBEenao0AW4InXC08kHIsIACnjEv08g0jPlOCIdO0FoABkrn8291jRvZh0QDK0uXvRzC5NOg6RwUAJjkgXmltya4B7gc1nL/Xls5e6frVZEtVe4F80tc5JOg6RwUAJjkj37iI2U/1zVl4/bCiJqs3YL5KOQWSwUIIj0r1ZhC/+G31zS/7F1jX+RtIBydDUXvC5wF+SjkNksFCCI9KN+KV/fwPGOnDvnPwDCYckQ9fPaGpVPzCRXlKCI9KzR4A2oOb3T+Ueb8v7mqQDkqGlUPTVNWm7JOk4RAYTJTgiPWhuya0GbgM2X9ZG7rEFhYeTjkmGljV5LqWptTXpOEQGEyU4Ir1zF+F8SV36WG5me8Hbkg5IhoZcwVfX1di3k45DZLBRgiPSC80tucXA/cDEBSt89cw5hXuSjkmGhqVr/AKaWvVN2iJ9pARHpPduBmqA9K8fab9/ZbsvTzogqW5r8t46oS71naTjEBmMlOCI9FJzS24+8A9g0op28re/nP9X0jFJdVve5j+gqXVV0nGIDEZKcET65q+AAzWXP5F7/M3VvijpgKQ6rcr56xPqUj9JOg6RwUoJjkgfNLfk3gSagUn5It7ckvtH0jFJdVqV82/S1JpLOg6RwUoJjkjf/QNYCQy/4bl8y/zlxVeTDkiqy/I2f2n8iNRvk45DZDBTgiPSR80tuVXA9cBEgMufyP2ffmlc+kuh6MVlbf5Jmlo96VhEBjMlOCLr515gETB65pzC/Pv02Lj0k1lL/fdTfrJ8ZtJxiAx2SnBE1kNzSy4HXAGMA1I/vb/9zjdWFRckHJYMcktW+8KXlhQ/k3QcItVACY7I+nsauAOY3F6geOHDuT8Xil5IOCYZpApF93+/UTjpsKtWrk46FpFqoARHZD3FXxq/FlgOjH5wbuH1e14t3JlwWDJIvbik+Mf9frPy/5KOQ6RaKMER2QDNLbmVwCXEpqqfP9B+z8KVxbkJhyWDzJLVvnD2Uv9U0nGIVBMlOCIbqLkl9yxwO7Blvoif/2D7n/NFzycdlwwOhaIX1TQl0v+U4Ij0jxuAN4Exjy8oLr71xfytSQckg8Oj84u/UtOUSP9TgiPSD+J34/waGAukL34k9/ATCwoPJxyWDHBPvl54+Lt3tX056ThEqpESHJF+0tySawFuArYG7Jw72/42d1lxVsJhyQA1p7U479LH2hubW3JqzhTZCJTgiPSvm4CHgS1zRYpNd7Rdt6zNlyQdlAwsrWt8xXXP5o7+2f3t85OORaRaKcER6UfNLbkC8FtgHrD56yt99Y9ntl3TXvC2hEOTAaK94Pk/P5878yu3rnkg6VhEqpkSHJF+Fvvj/AJwYPTjC4qLr3gid33RXb8tNMS5O7e+mD//hufylyUdi0i1U4IjshE0t+QWAT8jdDqubW7Jv3j7y4XbEg5LEnbPq4X/u+TR3Nfjl0SKyEakBEdkI2luyb0A/AaYAqTPf7D9/plz8nclHJYk5J5X8w/8aGb78fF3zERkI1OCI7JxzQT+AkwF7Lx72v/14Nz8vQnHJJvYzDn5J394b/uxzS25ZUnHIjJUKMER2YhiU8QNhB/lnArYuXe13/7IvML9iQYmm8wDr+WfOe+e9g83t+ReSzoWkaFECY7IRhafrLoCuBeYBtjZd7bd+uDcwsxEA5ONbuac/NPfu7v9w80tuZeTjkVkqDE92CGyaTQ2ZDPAacC+wCuAf/2dNQcesHXmoEQDk43ijtn5J39yX/sJzS2555KORWQoUoIjsgk1NmSzwMnAAYQkp/jFfWveccg2mUMTDUz6jbtz20uFhy94qP3j8dutRSQBSnBENrHGhmwa+DhwCDAbKJ6wS2an43bKHpVNWzbR4GSD5Aqeu/yJ3L+aW/Kfb27JvZh0PCJDmRIckQQ0NmRTwPHAB4DXgPZ9p6QnnrlvzQmjam1MstHJ+ljW5it+cl/bXx6dX/xGc0tOv0EmkjAlOCIJaWzIGqEW5+PAG8DySSNtxHcOqj1u8qjUtESDkz6Z01p8/ft3t101d7n/T/ySRxFJmBIckYQ1NmSnA2cSftphYTZF6pvvrj3s7ZPS+yQcmvTCw/MKL/zo3rZfrs7zm+aW3Oqk4xGRQAmOyADQ2JCdSEhytiA0Wfmn3559+wd3yByRTlk62eikkqJ78abn84/87vHcucBfmltyxaRjEpFOSnBEBojGhuwI4FPA3sAcIP+urdOTT9uz5sNjhtn4ZKOTUm+sKi45/8H2ux6ZX/xec0vu4aTjEZF1KcERGUBi5+MjgOOAhcCK4RnSX96/5qB9pqTfmTKzZCMc2orufvcrhScveKj9rjV5/re5JfdK0jGJSGVKcEQGoMaG7G6ELwUcDswF/ICt05NP3aPmyM2G2+bJRjc0vbnal/zywbb7H55X/DPwh+aW3PKkYxKRrinBERmgGhuyowiPkr8LWAwsH5Yh/cV9a969/1bpA1Jm+qmVTaDo7ve+Wnjq/AfbZ67OczHwRPyNMREZwJTgiAxg8VHyXYFTgTpCbU5xvy3TW5y+Z/bIcSNSWyQaYJV7Y1Vx0UUP5x5+YG6hGfi9fg1cZPBQgiMyCDQ2ZEcS+uUcTKjNWZZJYZ/YLbv7odtmDhpZY/XJRlhdVrR7603P5x6/7tn8M0Xnt8BjqrURGVyU4IgMErE2Z2dCbU49MB9oH54h/am31+x14LT0u4dlbESiQQ5ya/K++vaX849e/nju5bYC9xFqbVqTjktE+k4JjsggEx8nPxg4EkgTEp18fS01n9mzZv99t0zvX5O22kSDHGTyRc/NnFN47NePtL+0rI1ngD8CL6nWRmTwUoIjMkg1NmTrgfcB7yd8C/J8oLDFSBt+2h4173r7pNTemZRlEg1ygMsXPf/EguLTlzza/u95y/0l4A/AU0psRAY/JTgig1xjQ3Y84btzDgLagQWATxppIz66a3aPvSen966rsdFJxjjQrGz35fe/Vnj06qdy8xav8tcJNTYPN7fk8knHJiL9QwmOSJVobMhOJjRb7QPkCF8UmM+mSB2zU2bHA6dm9p48yqYN5e8KnLe8OPufs/LP3vhcflG+yCrgRuDu5pZcW9KxiUj/UoIjUmUaG7JbEvroHAikCE9drQLYaUJq7FE7ZvbYbWJ6xoisjUwwzE1mTd5XPfl68Ynrn83Nen5xsZ3QlHcz4cmoNQmHJyIbiRIckSoVvyhwH0Lz1VigDVgEFDIp7NBtMtP2mZLeYftxqYbRtTY2yVj727I2X9KyuNhy75z87DtnF9oKjgOPAX8H/q0fxhSpfkpwRKpcY0M2DWxPqNHZh1CrswJ4EygCzNgiNf7AqZkddpqQ2mHiSNt6sP3mVdHdF630uc8uKrb8Y1Z+9pOvF53whFkrcCvwYHNLbkmyUYrIpqQER2QIaWzIjiZ8l87+wE6EZCcPvEGo4WHzOhv2vm0z2+88IbXNpFE2acwwmzDQfhaiUPTim2v89fnLff6LS4qv3fpSfsG85Z6No5cAM4GngJebW3KF5CIVkaQowREZohobssOA7YAZwL5Ax5cEthJqeIoAwzOk95qcnjh9QmrS1vWpSZNG2qSxw23zTfUIetG9+OZqXzR/hc97ZWlx3rOLivMenldYujpPXYzZgVmEpOY5YL4e8xYRJTgiQmNDNgVsRajV2Se+tvhXAJYDK+NrsilSu01MjZsyOlU/briNHDvcRo6utZGjahg5ssZGjsjaqOFZRtakraardRbdvegU1uRZubLdl69oZ3lrmy9busaXL1ntyxet9OULVhSXt7xRXLUqxwg6kxkjJGH/Bh4FWppbcks32s4RkUFJCY6IrKOxIZsFNgcmAW8DGoCphCYt4v8c4Xt3Sv/W6rxrQCZFKpPCMilSKcPaCxTaChSLoeMvQAaoBWpK/kNnMrOckMy0AK8B84DlqqURke4owRGRXomdlScQkp4xwDhgPLAZ4SmtMYSOvR7/eiMFrCH0m3mD8JTXQkINTSvhke5lSmZEpK+U4IhIv4g/BjoMGEloTkoRamBS8a9AqOEpxterCTUx7YkELCJVTQmOiIiIVJ0B9einiIiISH9QgiMiIiJVRwmOiIiIVB0lOCIiIlJ1lOCIiIhI1VGCIyIiIlVHCY6IiIhUHSU4IiIiUnWU4IiIiEjVUYIjIiIiVUcJjoiIiFQdJTgiIiJSdZTgiIiISNVRgiMiIiJVRwmOiIiIVB0lOCIiIlJ1lOCIiIhI1VGCIyIiIlVHCY6IiIhUHSU4IiIiUnWU4IiIiEjVUYIjIiIiVUcJjoiIiFQdJTgiIiJSdZTgiIiISNX5/1n0hXx5TuvyAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "my_ghg = my_echo[my_echo[\"GHG_CO2_RELEASES\"].notna()]\n",
     "\n",
     "plt.pie([my_ghg.shape[0], num_facilities - my_ghg.shape[0]], labels=[\"Reporting GHG Emissions\", \"Not Reporting GHG Emissions\"], autopct='%1.1f%%', shadow=True)\n",
     "\n",
-    "plt.title('Of the %s facilities reporting to ECHO in %s, %s report greenhouse gas emissions.' %(num_facilities, my_zip, my_ghg.shape[0]))\n"
+    "plt.title('Of the %s facilities reporting to ECHO in %s, %s report greenhouse gas emissions.' %(num_facilities, my_city, my_ghg.shape[0]))\n"
    ]
   },
   {
@@ -347,37 +220,473 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'Count' is the number of facilities reporting; all of the other numbers are statistics on the greenhouse gas emissions of all of the facilities in Minneapolis, measured in metric tons of CO2e.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "count         9.000000\n",
+       "mean     194459.444444\n",
+       "std      307656.828653\n",
+       "min       28139.000000\n",
+       "25%       53281.000000\n",
+       "50%       95382.000000\n",
+       "75%      150290.000000\n",
+       "max      999751.000000\n",
+       "Name: GHG_CO2_RELEASES, dtype: float64"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "print(\"'Count' is the number of facilities reporting; all of the other numbers are statistics on the greenhouse gas emissions of all of the facilities in %s, measured in metric tons of CO2e.\" %my_zip)\n",
+    "print(\"'Count' is the number of facilities reporting; all of the other numbers are statistics on the greenhouse gas emissions of all of the facilities in %s, measured in metric tons of CO2e.\" %my_city)\n",
     "my_ghg[\"GHG_CO2_RELEASES\"].describe()"
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/Eric/anaconda3/lib/python3.7/site-packages/ipykernel_launcher.py:3: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n",
+      "  This is separate from the ipykernel package so we can avoid doing imports until\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div style=\"width:100%;\"><div style=\"position:relative;width:100%;height:0;padding-bottom:60%;\"><iframe src=\"about:blank\" style=\"position:absolute;width:100%;height:100%;left:0;top:0;border:none !important;\" data-html=PCFET0NUWVBFIGh0bWw+CjxoZWFkPiAgICAKICAgIDxtZXRhIGh0dHAtZXF1aXY9ImNvbnRlbnQtdHlwZSIgY29udGVudD0idGV4dC9odG1sOyBjaGFyc2V0PVVURi04IiAvPgogICAgCiAgICAgICAgPHNjcmlwdD4KICAgICAgICAgICAgTF9OT19UT1VDSCA9IGZhbHNlOwogICAgICAgICAgICBMX0RJU0FCTEVfM0QgPSBmYWxzZTsKICAgICAgICA8L3NjcmlwdD4KICAgIAogICAgPHNjcmlwdCBzcmM9Imh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vbGVhZmxldEAxLjUuMS9kaXN0L2xlYWZsZXQuanMiPjwvc2NyaXB0PgogICAgPHNjcmlwdCBzcmM9Imh0dHBzOi8vY29kZS5qcXVlcnkuY29tL2pxdWVyeS0xLjEyLjQubWluLmpzIj48L3NjcmlwdD4KICAgIDxzY3JpcHQgc3JjPSJodHRwczovL21heGNkbi5ib290c3RyYXBjZG4uY29tL2Jvb3RzdHJhcC8zLjIuMC9qcy9ib290c3RyYXAubWluLmpzIj48L3NjcmlwdD4KICAgIDxzY3JpcHQgc3JjPSJodHRwczovL2NkbmpzLmNsb3VkZmxhcmUuY29tL2FqYXgvbGlicy9MZWFmbGV0LmF3ZXNvbWUtbWFya2Vycy8yLjAuMi9sZWFmbGV0LmF3ZXNvbWUtbWFya2Vycy5qcyI+PC9zY3JpcHQ+CiAgICA8bGluayByZWw9InN0eWxlc2hlZXQiIGhyZWY9Imh0dHBzOi8vY2RuLmpzZGVsaXZyLm5ldC9ucG0vbGVhZmxldEAxLjUuMS9kaXN0L2xlYWZsZXQuY3NzIi8+CiAgICA8bGluayByZWw9InN0eWxlc2hlZXQiIGhyZWY9Imh0dHBzOi8vbWF4Y2RuLmJvb3RzdHJhcGNkbi5jb20vYm9vdHN0cmFwLzMuMi4wL2Nzcy9ib290c3RyYXAubWluLmNzcyIvPgogICAgPGxpbmsgcmVsPSJzdHlsZXNoZWV0IiBocmVmPSJodHRwczovL21heGNkbi5ib290c3RyYXBjZG4uY29tL2Jvb3RzdHJhcC8zLjIuMC9jc3MvYm9vdHN0cmFwLXRoZW1lLm1pbi5jc3MiLz4KICAgIDxsaW5rIHJlbD0ic3R5bGVzaGVldCIgaHJlZj0iaHR0cHM6Ly9tYXhjZG4uYm9vdHN0cmFwY2RuLmNvbS9mb250LWF3ZXNvbWUvNC42LjMvY3NzL2ZvbnQtYXdlc29tZS5taW4uY3NzIi8+CiAgICA8bGluayByZWw9InN0eWxlc2hlZXQiIGhyZWY9Imh0dHBzOi8vY2RuanMuY2xvdWRmbGFyZS5jb20vYWpheC9saWJzL0xlYWZsZXQuYXdlc29tZS1tYXJrZXJzLzIuMC4yL2xlYWZsZXQuYXdlc29tZS1tYXJrZXJzLmNzcyIvPgogICAgPGxpbmsgcmVsPSJzdHlsZXNoZWV0IiBocmVmPSJodHRwczovL3Jhd2Nkbi5naXRoYWNrLmNvbS9weXRob24tdmlzdWFsaXphdGlvbi9mb2xpdW0vbWFzdGVyL2ZvbGl1bS90ZW1wbGF0ZXMvbGVhZmxldC5hd2Vzb21lLnJvdGF0ZS5jc3MiLz4KICAgIDxzdHlsZT5odG1sLCBib2R5IHt3aWR0aDogMTAwJTtoZWlnaHQ6IDEwMCU7bWFyZ2luOiAwO3BhZGRpbmc6IDA7fTwvc3R5bGU+CiAgICA8c3R5bGU+I21hcCB7cG9zaXRpb246YWJzb2x1dGU7dG9wOjA7Ym90dG9tOjA7cmlnaHQ6MDtsZWZ0OjA7fTwvc3R5bGU+CiAgICAKICAgICAgICAgICAgPG1ldGEgbmFtZT0idmlld3BvcnQiIGNvbnRlbnQ9IndpZHRoPWRldmljZS13aWR0aCwKICAgICAgICAgICAgICAgIGluaXRpYWwtc2NhbGU9MS4wLCBtYXhpbXVtLXNjYWxlPTEuMCwgdXNlci1zY2FsYWJsZT1ubyIgLz4KICAgICAgICAgICAgPHN0eWxlPgogICAgICAgICAgICAgICAgI21hcF9jOTA3ZTllMWZmYzM0ZDFmODhkYTI0ZDZlMTRhMDkxYiB7CiAgICAgICAgICAgICAgICAgICAgcG9zaXRpb246IHJlbGF0aXZlOwogICAgICAgICAgICAgICAgICAgIHdpZHRoOiAxMDAuMCU7CiAgICAgICAgICAgICAgICAgICAgaGVpZ2h0OiAxMDAuMCU7CiAgICAgICAgICAgICAgICAgICAgbGVmdDogMC4wJTsKICAgICAgICAgICAgICAgICAgICB0b3A6IDAuMCU7CiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgIDwvc3R5bGU+CiAgICAgICAgCjwvaGVhZD4KPGJvZHk+ICAgIAogICAgCiAgICAgICAgICAgIDxkaXYgY2xhc3M9ImZvbGl1bS1tYXAiIGlkPSJtYXBfYzkwN2U5ZTFmZmMzNGQxZjg4ZGEyNGQ2ZTE0YTA5MWIiID48L2Rpdj4KICAgICAgICAKPC9ib2R5Pgo8c2NyaXB0PiAgICAKICAgIAogICAgICAgICAgICB2YXIgbWFwX2M5MDdlOWUxZmZjMzRkMWY4OGRhMjRkNmUxNGEwOTFiID0gTC5tYXAoCiAgICAgICAgICAgICAgICAibWFwX2M5MDdlOWUxZmZjMzRkMWY4OGRhMjRkNmUxNGEwOTFiIiwKICAgICAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICAgICBjZW50ZXI6IFswLCAwXSwKICAgICAgICAgICAgICAgICAgICBjcnM6IEwuQ1JTLkVQU0czODU3LAogICAgICAgICAgICAgICAgICAgIHpvb206IDEsCiAgICAgICAgICAgICAgICAgICAgem9vbUNvbnRyb2w6IHRydWUsCiAgICAgICAgICAgICAgICAgICAgcHJlZmVyQ2FudmFzOiBmYWxzZSwKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgKTsKCiAgICAgICAgICAgIAoKICAgICAgICAKICAgIAogICAgICAgICAgICB2YXIgdGlsZV9sYXllcl9lNjQwZjA0MjNmODM0NGYyOTI0YmFkNDhlMDJmNjkwMiA9IEwudGlsZUxheWVyKAogICAgICAgICAgICAgICAgImh0dHBzOi8ve3N9LnRpbGUub3BlbnN0cmVldG1hcC5vcmcve3p9L3t4fS97eX0ucG5nIiwKICAgICAgICAgICAgICAgIHsiYXR0cmlidXRpb24iOiAiRGF0YSBieSBcdTAwMjZjb3B5OyBcdTAwM2NhIGhyZWY9XCJodHRwOi8vb3BlbnN0cmVldG1hcC5vcmdcIlx1MDAzZU9wZW5TdHJlZXRNYXBcdTAwM2MvYVx1MDAzZSwgdW5kZXIgXHUwMDNjYSBocmVmPVwiaHR0cDovL3d3dy5vcGVuc3RyZWV0bWFwLm9yZy9jb3B5cmlnaHRcIlx1MDAzZU9EYkxcdTAwM2MvYVx1MDAzZS4iLCAiZGV0ZWN0UmV0aW5hIjogZmFsc2UsICJtYXhOYXRpdmVab29tIjogMTgsICJtYXhab29tIjogMTgsICJtaW5ab29tIjogMCwgIm5vV3JhcCI6IGZhbHNlLCAib3BhY2l0eSI6IDEsICJzdWJkb21haW5zIjogImFiYyIsICJ0bXMiOiBmYWxzZX0KICAgICAgICAgICAgKS5hZGRUbyhtYXBfYzkwN2U5ZTFmZmMzNGQxZjg4ZGEyNGQ2ZTE0YTA5MWIpOwogICAgICAgIAogICAgCiAgICAgICAgICAgIHZhciBjaXJjbGVfbWFya2VyXzkzYjllMmJiOWU5YzQxOWM4YWQ5NjJkMjM4NTc4ZmVhID0gTC5jaXJjbGVNYXJrZXIoCiAgICAgICAgICAgICAgICBbNDQuOTczNDc0LCAtOTMuMjY3Njk1XSwKICAgICAgICAgICAgICAgIHsiYnViYmxpbmdNb3VzZUV2ZW50cyI6IHRydWUsICJjb2xvciI6ICJibGFjayIsICJkYXNoQXJyYXkiOiBudWxsLCAiZGFzaE9mZnNldCI6IG51bGwsICJmaWxsIjogdHJ1ZSwgImZpbGxDb2xvciI6ICJvcmFuZ2UiLCAiZmlsbE9wYWNpdHkiOiAwLjQsICJmaWxsUnVsZSI6ICJldmVub2RkIiwgImxpbmVDYXAiOiAicm91bmQiLCAibGluZUpvaW4iOiAicm91bmQiLCAib3BhY2l0eSI6IDEuMCwgInJhZGl1cyI6IDE0LCAic3Ryb2tlIjogdHJ1ZSwgIndlaWdodCI6IDF9CiAgICAgICAgICAgICkuYWRkVG8obWFwX2M5MDdlOWUxZmZjMzRkMWY4OGRhMjRkNmUxNGEwOTFiKTsKICAgICAgICAKICAgIAogICAgICAgIHZhciBwb3B1cF85MGNjZmQyMDJjNGU0NjlkYmU3NGEyYzMxOGE5NDlmZCA9IEwucG9wdXAoeyJtYXhXaWR0aCI6ICIxMDAlIn0pOwoKICAgICAgICAKICAgICAgICAgICAgdmFyIGh0bWxfNjY3MTUyNzM2NWU1NDBjN2EwYjBjMDc5NDNkMjhjMTAgPSAkKGA8ZGl2IGlkPSJodG1sXzY2NzE1MjczNjVlNTQwYzdhMGIwYzA3OTQzZDI4YzEwIiBzdHlsZT0id2lkdGg6IDEwMC4wJTsgaGVpZ2h0OiAxMDAuMCU7Ij5OUkcgRU5FUkdZIENFTlRFUiBNSU5ORUFQT0xJUyByZWxlYXNlZCAxMDAsMzk3IHRvbnMgb2YgR0hHIGVtaXNzaW9ucyBsYXN0IHllYXIuPC9kaXY+YClbMF07CiAgICAgICAgICAgIHBvcHVwXzkwY2NmZDIwMmM0ZTQ2OWRiZTc0YTJjMzE4YTk0OWZkLnNldENvbnRlbnQoaHRtbF82NjcxNTI3MzY1ZTU0MGM3YTBiMGMwNzk0M2QyOGMxMCk7CiAgICAgICAgCgogICAgICAgIGNpcmNsZV9tYXJrZXJfOTNiOWUyYmI5ZTljNDE5YzhhZDk2MmQyMzg1NzhmZWEuYmluZFBvcHVwKHBvcHVwXzkwY2NmZDIwMmM0ZTQ2OWRiZTc0YTJjMzE4YTk0OWZkKQogICAgICAgIDsKCiAgICAgICAgCiAgICAKICAgIAogICAgICAgICAgICB2YXIgY2lyY2xlX21hcmtlcl82YmQwMThiNzRlY2U0MTU3OGE4ODExM2U3MWY3ODVhNyA9IEwuY2lyY2xlTWFya2VyKAogICAgICAgICAgICAgICAgWzQ0Ljg5MzA4OSwgLTkzLjIzMjQzM10sCiAgICAgICAgICAgICAgICB7ImJ1YmJsaW5nTW91c2VFdmVudHMiOiB0cnVlLCAiY29sb3IiOiAiYmxhY2siLCAiZGFzaEFycmF5IjogbnVsbCwgImRhc2hPZmZzZXQiOiBudWxsLCAiZmlsbCI6IHRydWUsICJmaWxsQ29sb3IiOiAib3JhbmdlIiwgImZpbGxPcGFjaXR5IjogMC40LCAiZmlsbFJ1bGUiOiAiZXZlbm9kZCIsICJsaW5lQ2FwIjogInJvdW5kIiwgImxpbmVKb2luIjogInJvdW5kIiwgIm9wYWNpdHkiOiAxLjAsICJyYWRpdXMiOiA2LCAic3Ryb2tlIjogdHJ1ZSwgIndlaWdodCI6IDF9CiAgICAgICAgICAgICkuYWRkVG8obWFwX2M5MDdlOWUxZmZjMzRkMWY4OGRhMjRkNmUxNGEwOTFiKTsKICAgICAgICAKICAgIAogICAgICAgIHZhciBwb3B1cF9iODdhY2ZmMGJhZDE0ZWYwOGU0MzJiMzcxY2NiZTA5MSA9IEwucG9wdXAoeyJtYXhXaWR0aCI6ICIxMDAlIn0pOwoKICAgICAgICAKICAgICAgICAgICAgdmFyIGh0bWxfOTIyMjQ2MWU4MWIyNDdkYjhkYmE5ZTFlOGQwMWZkOTAgPSAkKGA8ZGl2IGlkPSJodG1sXzkyMjI0NjFlODFiMjQ3ZGI4ZGJhOWUxZThkMDFmZDkwIiBzdHlsZT0id2lkdGg6IDEwMC4wJTsgaGVpZ2h0OiAxMDAuMCU7Ij5NRVRST1BPTElUQU4gQUlSUE9SVFMgQ09NTUlTU0lPTiByZWxlYXNlZCAyOCwxMzkgdG9ucyBvZiBHSEcgZW1pc3Npb25zIGxhc3QgeWVhci48L2Rpdj5gKVswXTsKICAgICAgICAgICAgcG9wdXBfYjg3YWNmZjBiYWQxNGVmMDhlNDMyYjM3MWNjYmUwOTEuc2V0Q29udGVudChodG1sXzkyMjI0NjFlODFiMjQ3ZGI4ZGJhOWUxZThkMDFmZDkwKTsKICAgICAgICAKCiAgICAgICAgY2lyY2xlX21hcmtlcl82YmQwMThiNzRlY2U0MTU3OGE4ODExM2U3MWY3ODVhNy5iaW5kUG9wdXAocG9wdXBfYjg3YWNmZjBiYWQxNGVmMDhlNDMyYjM3MWNjYmUwOTEpCiAgICAgICAgOwoKICAgICAgICAKICAgIAogICAgCiAgICAgICAgICAgIHZhciBjaXJjbGVfbWFya2VyX2ViMmVhY2U1NzRlOTQyYzk5NGUwMjBiMzQ3ZDczYjkyID0gTC5jaXJjbGVNYXJrZXIoCiAgICAgICAgICAgICAgICBbNDQuOTc5NjcsIC05My4yNjk4OV0sCiAgICAgICAgICAgICAgICB7ImJ1YmJsaW5nTW91c2VFdmVudHMiOiB0cnVlLCAiY29sb3IiOiAiYmxhY2siLCAiZGFzaEFycmF5IjogbnVsbCwgImRhc2hPZmZzZXQiOiBudWxsLCAiZmlsbCI6IHRydWUsICJmaWxsQ29sb3IiOiAib3JhbmdlIiwgImZpbGxPcGFjaXR5IjogMC40LCAiZmlsbFJ1bGUiOiAiZXZlbm9kZCIsICJsaW5lQ2FwIjogInJvdW5kIiwgImxpbmVKb2luIjogInJvdW5kIiwgIm9wYWNpdHkiOiAxLjAsICJyYWRpdXMiOiAxMCwgInN0cm9rZSI6IHRydWUsICJ3ZWlnaHQiOiAxfQogICAgICAgICAgICApLmFkZFRvKG1hcF9jOTA3ZTllMWZmYzM0ZDFmODhkYTI0ZDZlMTRhMDkxYik7CiAgICAgICAgCiAgICAKICAgICAgICB2YXIgcG9wdXBfOWIzYWU4ZmMxMzk3NDU0Yzk1MTIyMDE4MjA0ZjMxMjcgPSBMLnBvcHVwKHsibWF4V2lkdGgiOiAiMTAwJSJ9KTsKCiAgICAgICAgCiAgICAgICAgICAgIHZhciBodG1sX2JiMGI0ZWFkYjQ3NDRhMmViM2I5YjdmNmY5NzdlODQ5ID0gJChgPGRpdiBpZD0iaHRtbF9iYjBiNGVhZGI0NzQ0YTJlYjNiOWI3ZjZmOTc3ZTg0OSIgc3R5bGU9IndpZHRoOiAxMDAuMCU7IGhlaWdodDogMTAwLjAlOyI+Tk9SVEhFUk4gU1RBVEUgUE9XRVIgQ09NUEFOWSwgQSBNSU5ORVNPVEEgQ09SUE9SQVRJT04gLSBOT1JUSCBEQUtPVEEgcmVsZWFzZWQgOTUsMzgyIHRvbnMgb2YgR0hHIGVtaXNzaW9ucyBsYXN0IHllYXIuPC9kaXY+YClbMF07CiAgICAgICAgICAgIHBvcHVwXzliM2FlOGZjMTM5NzQ1NGM5NTEyMjAxODIwNGYzMTI3LnNldENvbnRlbnQoaHRtbF9iYjBiNGVhZGI0NzQ0YTJlYjNiOWI3ZjZmOTc3ZTg0OSk7CiAgICAgICAgCgogICAgICAgIGNpcmNsZV9tYXJrZXJfZWIyZWFjZTU3NGU5NDJjOTk0ZTAyMGIzNDdkNzNiOTIuYmluZFBvcHVwKHBvcHVwXzliM2FlOGZjMTM5NzQ1NGM5NTEyMjAxODIwNGYzMTI3KQogICAgICAgIDsKCiAgICAgICAgCiAgICAKICAgIAogICAgICAgICAgICB2YXIgY2lyY2xlX21hcmtlcl8zYzgxMzI3ODAyYTg0MzA0ODlhZTIxOGU2Y2EyNmY1MyA9IEwuY2lyY2xlTWFya2VyKAogICAgICAgICAgICAgICAgWzQ0Ljk3MjA2LCAtOTMuMjU3ODNdLAogICAgICAgICAgICAgICAgeyJidWJibGluZ01vdXNlRXZlbnRzIjogdHJ1ZSwgImNvbG9yIjogImJsYWNrIiwgImRhc2hBcnJheSI6IG51bGwsICJkYXNoT2Zmc2V0IjogbnVsbCwgImZpbGwiOiB0cnVlLCAiZmlsbENvbG9yIjogIm9yYW5nZSIsICJmaWxsT3BhY2l0eSI6IDAuNCwgImZpbGxSdWxlIjogImV2ZW5vZGQiLCAibGluZUNhcCI6ICJyb3VuZCIsICJsaW5lSm9pbiI6ICJyb3VuZCIsICJvcGFjaXR5IjogMS4wLCAicmFkaXVzIjogNiwgInN0cm9rZSI6IHRydWUsICJ3ZWlnaHQiOiAxfQogICAgICAgICAgICApLmFkZFRvKG1hcF9jOTA3ZTllMWZmYzM0ZDFmODhkYTI0ZDZlMTRhMDkxYik7CiAgICAgICAgCiAgICAKICAgICAgICB2YXIgcG9wdXBfMTk3NDQxOGExOGMxNDJmNGJmMTI1YjQ3MzE0NDJjMzAgPSBMLnBvcHVwKHsibWF4V2lkdGgiOiAiMTAwJSJ9KTsKCiAgICAgICAgCiAgICAgICAgICAgIHZhciBodG1sXzI2ZThjYjM4YjZhODQyZDdhY2M0OTYzYzcwMTk4NDA1ID0gJChgPGRpdiBpZD0iaHRtbF8yNmU4Y2IzOGI2YTg0MmQ3YWNjNDk2M2M3MDE5ODQwNSIgc3R5bGU9IndpZHRoOiAxMDAuMCU7IGhlaWdodDogMTAwLjAlOyI+SEVOTkVQSU4gQ09VTlRZIEVORVJHWSBDRU5URVIgcmVsZWFzZWQgMzUsMjQ0IHRvbnMgb2YgR0hHIGVtaXNzaW9ucyBsYXN0IHllYXIuPC9kaXY+YClbMF07CiAgICAgICAgICAgIHBvcHVwXzE5NzQ0MThhMThjMTQyZjRiZjEyNWI0NzMxNDQyYzMwLnNldENvbnRlbnQoaHRtbF8yNmU4Y2IzOGI2YTg0MmQ3YWNjNDk2M2M3MDE5ODQwNSk7CiAgICAgICAgCgogICAgICAgIGNpcmNsZV9tYXJrZXJfM2M4MTMyNzgwMmE4NDMwNDg5YWUyMThlNmNhMjZmNTMuYmluZFBvcHVwKHBvcHVwXzE5NzQ0MThhMThjMTQyZjRiZjEyNWI0NzMxNDQyYzMwKQogICAgICAgIDsKCiAgICAgICAgCiAgICAKICAgIAogICAgICAgICAgICB2YXIgY2lyY2xlX21hcmtlcl85NzEwOTBhYWUxZjM0ZmExODQ4MmIxMWI3ZDZjMDE0ZSA9IEwuY2lyY2xlTWFya2VyKAogICAgICAgICAgICAgICAgWzQ0Ljk3NjE5LCAtOTMuMjc0ODJdLAogICAgICAgICAgICAgICAgeyJidWJibGluZ01vdXNlRXZlbnRzIjogdHJ1ZSwgImNvbG9yIjogImJsYWNrIiwgImRhc2hBcnJheSI6IG51bGwsICJkYXNoT2Zmc2V0IjogbnVsbCwgImZpbGwiOiB0cnVlLCAiZmlsbENvbG9yIjogIm9yYW5nZSIsICJmaWxsT3BhY2l0eSI6IDAuNCwgImZpbGxSdWxlIjogImV2ZW5vZGQiLCAibGluZUNhcCI6ICJyb3VuZCIsICJsaW5lSm9pbiI6ICJyb3VuZCIsICJvcGFjaXR5IjogMS4wLCAicmFkaXVzIjogMTAsICJzdHJva2UiOiB0cnVlLCAid2VpZ2h0IjogMX0KICAgICAgICAgICAgKS5hZGRUbyhtYXBfYzkwN2U5ZTFmZmMzNGQxZjg4ZGEyNGQ2ZTE0YTA5MWIpOwogICAgICAgIAogICAgCiAgICAgICAgdmFyIHBvcHVwXzI3ZTZlODJmODViYzQwMzBiZWZhZTFlOTFlYzkwYTY0ID0gTC5wb3B1cCh7Im1heFdpZHRoIjogIjEwMCUifSk7CgogICAgICAgIAogICAgICAgICAgICB2YXIgaHRtbF8xOTRlMDlmYzM5MDU0MGJhYTM4MDEzYWM1MjRhZDBlYSA9ICQoYDxkaXYgaWQ9Imh0bWxfMTk0ZTA5ZmMzOTA1NDBiYWEzODAxM2FjNTI0YWQwZWEiIHN0eWxlPSJ3aWR0aDogMTAwLjAlOyBoZWlnaHQ6IDEwMC4wJTsiPkNFTlRFUlBPSU5UIEVORVJHWSBNSU5ORVNPVEEgR0FTIHJlbGVhc2VkIDcyLDk2OSB0b25zIG9mIEdIRyBlbWlzc2lvbnMgbGFzdCB5ZWFyLjwvZGl2PmApWzBdOwogICAgICAgICAgICBwb3B1cF8yN2U2ZTgyZjg1YmM0MDMwYmVmYWUxZTkxZWM5MGE2NC5zZXRDb250ZW50KGh0bWxfMTk0ZTA5ZmMzOTA1NDBiYWEzODAxM2FjNTI0YWQwZWEpOwogICAgICAgIAoKICAgICAgICBjaXJjbGVfbWFya2VyXzk3MTA5MGFhZTFmMzRmYTE4NDgyYjExYjdkNmMwMTRlLmJpbmRQb3B1cChwb3B1cF8yN2U2ZTgyZjg1YmM0MDMwYmVmYWUxZTkxZWM5MGE2NCkKICAgICAgICA7CgogICAgICAgIAogICAgCiAgICAKICAgICAgICAgICAgdmFyIGNpcmNsZV9tYXJrZXJfNmQ1YjM1NDI2YzMzNGVlZTg0ZTYwZWMxN2RkMWVlZGIgPSBMLmNpcmNsZU1hcmtlcigKICAgICAgICAgICAgICAgIFs0NC45Nzk2NywgLTkzLjI2OTg5XSwKICAgICAgICAgICAgICAgIHsiYnViYmxpbmdNb3VzZUV2ZW50cyI6IHRydWUsICJjb2xvciI6ICJibGFjayIsICJkYXNoQXJyYXkiOiBudWxsLCAiZGFzaE9mZnNldCI6IG51bGwsICJmaWxsIjogdHJ1ZSwgImZpbGxDb2xvciI6ICJvcmFuZ2UiLCAiZmlsbE9wYWNpdHkiOiAwLjQsICJmaWxsUnVsZSI6ICJldmVub2RkIiwgImxpbmVDYXAiOiAicm91bmQiLCAibGluZUpvaW4iOiAicm91bmQiLCAib3BhY2l0eSI6IDEuMCwgInJhZGl1cyI6IDYsICJzdHJva2UiOiB0cnVlLCAid2VpZ2h0IjogMX0KICAgICAgICAgICAgKS5hZGRUbyhtYXBfYzkwN2U5ZTFmZmMzNGQxZjg4ZGEyNGQ2ZTE0YTA5MWIpOwogICAgICAgIAogICAgCiAgICAgICAgdmFyIHBvcHVwXzE2ZDdmMGQyZDMxOTRkM2VhMGE4NWUwZGFjZjA1NzI3ID0gTC5wb3B1cCh7Im1heFdpZHRoIjogIjEwMCUifSk7CgogICAgICAgIAogICAgICAgICAgICB2YXIgaHRtbF9mY2ZkOWJiNDFmY2Q0YjJjODJkZjY3OTQwZDJmYTY3NSA9ICQoYDxkaXYgaWQ9Imh0bWxfZmNmZDliYjQxZmNkNGIyYzgyZGY2Nzk0MGQyZmE2NzUiIHN0eWxlPSJ3aWR0aDogMTAwLjAlOyBoZWlnaHQ6IDEwMC4wJTsiPlBVQkxJQyBTRVJWSUNFIENPTVBBTlkgT0YgQ09MT1JBRE8gLSBTVUJQQVJUIEREIHJlbGVhc2VkIDUzLDI4MSB0b25zIG9mIEdIRyBlbWlzc2lvbnMgbGFzdCB5ZWFyLjwvZGl2PmApWzBdOwogICAgICAgICAgICBwb3B1cF8xNmQ3ZjBkMmQzMTk0ZDNlYTBhODVlMGRhY2YwNTcyNy5zZXRDb250ZW50KGh0bWxfZmNmZDliYjQxZmNkNGIyYzgyZGY2Nzk0MGQyZmE2NzUpOwogICAgICAgIAoKICAgICAgICBjaXJjbGVfbWFya2VyXzZkNWIzNTQyNmMzMzRlZWU4NGU2MGVjMTdkZDFlZWRiLmJpbmRQb3B1cChwb3B1cF8xNmQ3ZjBkMmQzMTk0ZDNlYTBhODVlMGRhY2YwNTcyNykKICAgICAgICA7CgogICAgICAgIAogICAgCiAgICAKICAgICAgICAgICAgdmFyIGNpcmNsZV9tYXJrZXJfNGEyNTE5NzIxYzQ5NDQyYTk4MzQ2NGRlOTc4MjE0ZjIgPSBMLmNpcmNsZU1hcmtlcigKICAgICAgICAgICAgICAgIFs0NC45ODM1MSwgLTkzLjI4MDM3XSwKICAgICAgICAgICAgICAgIHsiYnViYmxpbmdNb3VzZUV2ZW50cyI6IHRydWUsICJjb2xvciI6ICJibGFjayIsICJkYXNoQXJyYXkiOiBudWxsLCAiZGFzaE9mZnNldCI6IG51bGwsICJmaWxsIjogdHJ1ZSwgImZpbGxDb2xvciI6ICJvcmFuZ2UiLCAiZmlsbE9wYWNpdHkiOiAwLjQsICJmaWxsUnVsZSI6ICJldmVub2RkIiwgImxpbmVDYXAiOiAicm91bmQiLCAibGluZUpvaW4iOiAicm91bmQiLCAib3BhY2l0eSI6IDEuMCwgInJhZGl1cyI6IDE0LCAic3Ryb2tlIjogdHJ1ZSwgIndlaWdodCI6IDF9CiAgICAgICAgICAgICkuYWRkVG8obWFwX2M5MDdlOWUxZmZjMzRkMWY4OGRhMjRkNmUxNGEwOTFiKTsKICAgICAgICAKICAgIAogICAgICAgIHZhciBwb3B1cF84NTJhMmZjOWU5OGM0YWU4YWUwYTBlM2Q5ZDc2NTJlMCA9IEwucG9wdXAoeyJtYXhXaWR0aCI6ICIxMDAlIn0pOwoKICAgICAgICAKICAgICAgICAgICAgdmFyIGh0bWxfN2M2ZmNiNjIxNjA4NGE1MmE1ZjVkYTQ2M2Y4OWM5OWQgPSAkKGA8ZGl2IGlkPSJodG1sXzdjNmZjYjYyMTYwODRhNTJhNWY1ZGE0NjNmODljOTlkIiBzdHlsZT0id2lkdGg6IDEwMC4wJTsgaGVpZ2h0OiAxMDAuMCU7Ij5IRU5ORVBJTiBFTkVSR1kgUkVDT1ZFUlkgQ0VOVEVSIHJlbGVhc2VkIDE1MCwyOTAgdG9ucyBvZiBHSEcgZW1pc3Npb25zIGxhc3QgeWVhci48L2Rpdj5gKVswXTsKICAgICAgICAgICAgcG9wdXBfODUyYTJmYzllOThjNGFlOGFlMGEwZTNkOWQ3NjUyZTAuc2V0Q29udGVudChodG1sXzdjNmZjYjYyMTYwODRhNTJhNWY1ZGE0NjNmODljOTlkKTsKICAgICAgICAKCiAgICAgICAgY2lyY2xlX21hcmtlcl80YTI1MTk3MjFjNDk0NDJhOTgzNDY0ZGU5NzgyMTRmMi5iaW5kUG9wdXAocG9wdXBfODUyYTJmYzllOThjNGFlOGFlMGEwZTNkOWQ3NjUyZTApCiAgICAgICAgOwoKICAgICAgICAKICAgIAogICAgCiAgICAgICAgICAgIHZhciBjaXJjbGVfbWFya2VyXzEzNGZhMGNjOGY5YTQ5ZmJiMjcwZTFhZDE1MjllY2EzID0gTC5jaXJjbGVNYXJrZXIoCiAgICAgICAgICAgICAgICBbNDQuOTc1ODgsIC05My4yMzM4Nl0sCiAgICAgICAgICAgICAgICB7ImJ1YmJsaW5nTW91c2VFdmVudHMiOiB0cnVlLCAiY29sb3IiOiAiYmxhY2siLCAiZGFzaEFycmF5IjogbnVsbCwgImRhc2hPZmZzZXQiOiBudWxsLCAiZmlsbCI6IHRydWUsICJmaWxsQ29sb3IiOiAib3JhbmdlIiwgImZpbGxPcGFjaXR5IjogMC40LCAiZmlsbFJ1bGUiOiAiZXZlbm9kZCIsICJsaW5lQ2FwIjogInJvdW5kIiwgImxpbmVKb2luIjogInJvdW5kIiwgIm9wYWNpdHkiOiAxLjAsICJyYWRpdXMiOiAyMCwgInN0cm9rZSI6IHRydWUsICJ3ZWlnaHQiOiAxfQogICAgICAgICAgICApLmFkZFRvKG1hcF9jOTA3ZTllMWZmYzM0ZDFmODhkYTI0ZDZlMTRhMDkxYik7CiAgICAgICAgCiAgICAKICAgICAgICB2YXIgcG9wdXBfNTI1NmY1YTk5YTM2NGIyODlmNjhjMzRmZGNmY2UzZGYgPSBMLnBvcHVwKHsibWF4V2lkdGgiOiAiMTAwJSJ9KTsKCiAgICAgICAgCiAgICAgICAgICAgIHZhciBodG1sX2Y3ZTcxNDQ1OWNiNTQ3YjA4ODE5MmM3OTg3ZThiMmY3ID0gJChgPGRpdiBpZD0iaHRtbF9mN2U3MTQ0NTljYjU0N2IwODgxOTJjNzk4N2U4YjJmNyIgc3R5bGU9IndpZHRoOiAxMDAuMCU7IGhlaWdodDogMTAwLjAlOyI+VU5JVkVSU0lUWSBPRiBNTiAtIFRXSU4gQ0lUSUVTIHJlbGVhc2VkIDIxNCw2ODIgdG9ucyBvZiBHSEcgZW1pc3Npb25zIGxhc3QgeWVhci48L2Rpdj5gKVswXTsKICAgICAgICAgICAgcG9wdXBfNTI1NmY1YTk5YTM2NGIyODlmNjhjMzRmZGNmY2UzZGYuc2V0Q29udGVudChodG1sX2Y3ZTcxNDQ1OWNiNTQ3YjA4ODE5MmM3OTg3ZThiMmY3KTsKICAgICAgICAKCiAgICAgICAgY2lyY2xlX21hcmtlcl8xMzRmYTBjYzhmOWE0OWZiYjI3MGUxYWQxNTI5ZWNhMy5iaW5kUG9wdXAocG9wdXBfNTI1NmY1YTk5YTM2NGIyODlmNjhjMzRmZGNmY2UzZGYpCiAgICAgICAgOwoKICAgICAgICAKICAgIAogICAgCiAgICAgICAgICAgIHZhciBjaXJjbGVfbWFya2VyXzdjNzFjYmNmYzBlODQ4NzE5N2I3ZWQ2ZjE1ZDdhZDkxID0gTC5jaXJjbGVNYXJrZXIoCiAgICAgICAgICAgICAgICBbNDUuMDIwMSwgLTkzLjI3NDRdLAogICAgICAgICAgICAgICAgeyJidWJibGluZ01vdXNlRXZlbnRzIjogdHJ1ZSwgImNvbG9yIjogImJsYWNrIiwgImRhc2hBcnJheSI6IG51bGwsICJkYXNoT2Zmc2V0IjogbnVsbCwgImZpbGwiOiB0cnVlLCAiZmlsbENvbG9yIjogIm9yYW5nZSIsICJmaWxsT3BhY2l0eSI6IDAuNCwgImZpbGxSdWxlIjogImV2ZW5vZGQiLCAibGluZUNhcCI6ICJyb3VuZCIsICJsaW5lSm9pbiI6ICJyb3VuZCIsICJvcGFjaXR5IjogMS4wLCAicmFkaXVzIjogMjAsICJzdHJva2UiOiB0cnVlLCAid2VpZ2h0IjogMX0KICAgICAgICAgICAgKS5hZGRUbyhtYXBfYzkwN2U5ZTFmZmMzNGQxZjg4ZGEyNGQ2ZTE0YTA5MWIpOwogICAgICAgIAogICAgCiAgICAgICAgdmFyIHBvcHVwXzkzNTYzYzE1YmY4ZjQ4MjRiMDRiNjQyMzNhMDQxNThhID0gTC5wb3B1cCh7Im1heFdpZHRoIjogIjEwMCUifSk7CgogICAgICAgIAogICAgICAgICAgICB2YXIgaHRtbF8zNGM4N2YxZmE5YWI0NWFjODU2MzQwYjY2YzczZTM5MiA9ICQoYDxkaXYgaWQ9Imh0bWxfMzRjODdmMWZhOWFiNDVhYzg1NjM0MGI2NmM3M2UzOTIiIHN0eWxlPSJ3aWR0aDogMTAwLjAlOyBoZWlnaHQ6IDEwMC4wJTsiPlhDRUwgRU5FUkdZIFJJVkVSU0lERSBHRU5FUkFUSU5HIFBMQU5UIHJlbGVhc2VkIDk5OSw3NTEgdG9ucyBvZiBHSEcgZW1pc3Npb25zIGxhc3QgeWVhci48L2Rpdj5gKVswXTsKICAgICAgICAgICAgcG9wdXBfOTM1NjNjMTViZjhmNDgyNGIwNGI2NDIzM2EwNDE1OGEuc2V0Q29udGVudChodG1sXzM0Yzg3ZjFmYTlhYjQ1YWM4NTYzNDBiNjZjNzNlMzkyKTsKICAgICAgICAKCiAgICAgICAgY2lyY2xlX21hcmtlcl83YzcxY2JjZmMwZTg0ODcxOTdiN2VkNmYxNWQ3YWQ5MS5iaW5kUG9wdXAocG9wdXBfOTM1NjNjMTViZjhmNDgyNGIwNGI2NDIzM2EwNDE1OGEpCiAgICAgICAgOwoKICAgICAgICAKICAgIAogICAgCiAgICAgICAgICAgIG1hcF9jOTA3ZTllMWZmYzM0ZDFmODhkYTI0ZDZlMTRhMDkxYi5maXRCb3VuZHMoCiAgICAgICAgICAgICAgICBbWzQ0Ljg5MzA4OSwgLTkzLjI4MDM3XSwgWzQ1LjAyMDEsIC05My4yMzI0MzNdXSwKICAgICAgICAgICAgICAgIHt9CiAgICAgICAgICAgICk7CiAgICAgICAgCjwvc2NyaXB0Pg== onload=\"this.contentDocument.open();this.contentDocument.write(atob(this.getAttribute('data-html')));this.contentDocument.close();\" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe></div></div>"
+      ],
+      "text/plain": [
+       "<folium.folium.Map at 0x11558e0d0>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Let's show a quick map of your area and the facilities in it\n",
+    "# Generate a scale by which we can classify facilities , and map them accordingly\n",
+    "my_ghg[\"quartile\"]=pd.qcut(my_ghg[\"GHG_CO2_RELEASES\"], 4, labels=False, duplicates=\"drop\") # quartiles\n",
+    "radii={0:6, 1:10, 2:14, 3: 20}\n",
+    "\n",
+    "def mapper(dataframe):\n",
+    "    # Initialize the map\n",
+    "    m = folium.Map()\n",
+    "\n",
+    "    # Add a clickable marker for each facility\n",
+    "    for index, row in dataframe.iterrows():\n",
+    "        folium.CircleMarker(\n",
+    "            location = [row[\"FAC_LAT\"], row[\"FAC_LONG\"]],\n",
+    "            popup = row[\"FAC_NAME\"]+\" released \"+str(\"{:,.0f}\".format(row[\"GHG_CO2_RELEASES\"]))+\" tons of GHG emissions last year.\",\n",
+    "            radius = radii[row[\"quartile\"]],\n",
+    "            color = \"black\",\n",
+    "            weight = 1,\n",
+    "            fill_color = \"orange\",\n",
+    "            fill_opacity= .4\n",
+    "        ).add_to(m)\n",
+    "\n",
+    "    bounds = m.get_bounds()\n",
+    "    m.fit_bounds(bounds)\n",
+    "    \n",
+    "    # Show the map\n",
+    "    return m\n",
+    "\n",
+    "map_of_facilities_in_my_area = mapper(my_ghg)\n",
+    "map_of_facilities_in_my_area"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Bonus:** Try entering the mean (from above) into https://www.epa.gov/energy/greenhouse-gas-equivalencies-calculator and see what an average facility in your zip code emits into the atmosphere compared to you."
+    "## What's the cost of these emissions?\n",
+    "On May 25, 2020, George Floyd, a Black man, was killed by white Minneapolis, MN police offficer Derek Chauvin. Chauvin kneeled on Floyd's neck for nearly nine minutes, after arresting him for alledgly using a counterfeit $20 bill.\n",
+    "\n",
+    "Every single day, the facilities mapped above release climate change-causing chemicals into the atmosphere - and they do so legally, in full public view (they report their numbers), and without reprcussion. \n",
+    "\n",
+    "The economic cost of these emissions can be calculated. The \"social cost of carbon\" is estimated to be about 50/ton. That is, every ton of GHG emitted represents a $50 cost to future generations, from rising sea levels that flood homes, strong storms that damage crops, and so on."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<h1>XCEL ENERGY RIVERSIDE GENERATING PLANT</h1><h4>999,751</h3> tons of GHGs emitted last year.<h3> $49,987,550</h3> The amount of climate damage, done legally and in full public view. It amounts to an uncompensated theft from the future. <h2>2,499,378 </h2> And that amount of money is this ^^^ many times more than the amount George Floyd was accused of counterfeiting."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h1>UNIVERSITY OF MN - TWIN CITIES</h1><h4>214,682</h3> tons of GHGs emitted last year.<h3> $10,734,100</h3> The amount of climate damage, done legally and in full public view. It amounts to an uncompensated theft from the future. <h2>536,705 </h2> And that amount of money is this ^^^ many times more than the amount George Floyd was accused of counterfeiting."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h1>HENNEPIN ENERGY RECOVERY CENTER</h1><h4>150,290</h3> tons of GHGs emitted last year.<h3> $7,514,500</h3> The amount of climate damage, done legally and in full public view. It amounts to an uncompensated theft from the future. <h2>375,725 </h2> And that amount of money is this ^^^ many times more than the amount George Floyd was accused of counterfeiting."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h1>NRG ENERGY CENTER MINNEAPOLIS</h1><h4>100,397</h3> tons of GHGs emitted last year.<h3> $5,019,850</h3> The amount of climate damage, done legally and in full public view. It amounts to an uncompensated theft from the future. <h2>250,992 </h2> And that amount of money is this ^^^ many times more than the amount George Floyd was accused of counterfeiting."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h1>NORTHERN STATE POWER COMPANY, A MINNESOTA CORPORATION - NORTH DAKOTA</h1><h4>95,382</h3> tons of GHGs emitted last year.<h3> $4,769,100</h3> The amount of climate damage, done legally and in full public view. It amounts to an uncompensated theft from the future. <h2>238,455 </h2> And that amount of money is this ^^^ many times more than the amount George Floyd was accused of counterfeiting."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h1>CENTERPOINT ENERGY MINNESOTA GAS</h1><h4>72,969</h3> tons of GHGs emitted last year.<h3> $3,648,450</h3> The amount of climate damage, done legally and in full public view. It amounts to an uncompensated theft from the future. <h2>182,422 </h2> And that amount of money is this ^^^ many times more than the amount George Floyd was accused of counterfeiting."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h1>PUBLIC SERVICE COMPANY OF COLORADO - SUBPART DD</h1><h4>53,281</h3> tons of GHGs emitted last year.<h3> $2,664,050</h3> The amount of climate damage, done legally and in full public view. It amounts to an uncompensated theft from the future. <h2>133,202 </h2> And that amount of money is this ^^^ many times more than the amount George Floyd was accused of counterfeiting."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h1>HENNEPIN COUNTY ENERGY CENTER</h1><h4>35,244</h3> tons of GHGs emitted last year.<h3> $1,762,200</h3> The amount of climate damage, done legally and in full public view. It amounts to an uncompensated theft from the future. <h2>88,110 </h2> And that amount of money is this ^^^ many times more than the amount George Floyd was accused of counterfeiting."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h1>METROPOLITAN AIRPORTS COMMISSION</h1><h4>28,139</h3> tons of GHGs emitted last year.<h3> $1,406,950</h3> The amount of climate damage, done legally and in full public view. It amounts to an uncompensated theft from the future. <h2>70,348 </h2> And that amount of money is this ^^^ many times more than the amount George Floyd was accused of counterfeiting."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "plt.bar(my_ghg[\"FAC_NAME\"], my_ghg[\"GHG_CO2_RELEASES\"])\n",
-    "plt.title(\"Total Facility Emissions from the most recent reporting year\")\n",
-    "plt.ylabel(\"metric tons CO2e (excluding Biogenic CO2)\")"
+    "my_ghg=my_ghg.sort_values(by=['GHG_CO2_RELEASES'], ascending=False)\n",
+    "for index,row in my_ghg.iterrows():\n",
+    "    display(HTML(\"<h1>\"+row[0]+\"</h1>\" + \\\n",
+    "                \"<h4>\"+str(\"{:,.0f}\".format(row[6]))+\"</h3> tons of GHGs emitted last year.\" + \\\n",
+    "                 \"<h3> $\"+str(\"{:,.0f}\".format(row[6]*50))+\"</h3> The amount of climate damage, done legally and in full public view. It amounts to an uncompensated theft from the future. \" + \\\n",
+    "                 \"<h2>\" +str(\"{:,.0f}\".format((row[6]*50)/20))+\" </h2> And that amount of money is this ^^^ many times more than the amount George Floyd was accused of counterfeiting.\"\n",
+    "                )\n",
+    "           )"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Next questions\n",
+    "## Clean Air Act violations\n",
+    "\n",
+    "But that's not all. Every day around the country, companies release \"criteria polluants\" - pollutants that are so harmful to human health, EPA has special authority to regulate them. The Clean Air Act sets up a system whereby facilities are permitted to emit these chemicals, up to a certain point. But EPA doesn't even enforce these permitted levels on a regular basis. \n",
+    "\n",
+    "Here we chart \"high priority\" violations of limits on criteria pollutants and instances where facilities were forced to pay. Compare whether the violations track with enforcement actions, and whether the penalties seem fitting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "id_list = my_echo[\"AIR_IDS\"].dropna()\n",
+    "ids=\"\"\n",
+    "for id in id_list:\n",
+    "    ids+= \"'\"+id+\"', \"\n",
+    "ids = ids[0:len(ids)-2]\n",
+    "\n",
+    "sql = \"select * from `ICIS-AIR_VIOLATION_HISTORY` where pgm_sys_id in (\"+ids+\")\"\n",
+    "url='http://apps.tlt.stonybrook.edu/echoepa/?query='\n",
+    "data_location=url+urllib.parse.quote(sql)\n",
+    "\n",
+    "v_data = pd.read_csv(data_location,encoding='iso-8859-1',header = 0)\n",
+    "v_data.set_index(\"pgm_sys_id\", inplace=True)\n",
+    "\n",
+    "sql = \"select * from `ICIS-AIR_FORMAL_ACTIONS` where pgm_sys_id in (\"+ids+\") and PENALTY_AMOUNT > 0\"\n",
+    "url='http://apps.tlt.stonybrook.edu/echoepa/?query='\n",
+    "data_location=url+urllib.parse.quote(sql)\n",
+    "\n",
+    "e_data = pd.read_csv(data_location,encoding='iso-8859-1',header = 0)\n",
+    "e_data.set_index(\"pgm_sys_id\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<h1>$73,778</h1>The following facilities/companies paid only this much in total for their violations."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h2> GAF MATERIALS CORP</h3>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h2> ABBOTT NORTHWESTERN HOSPITAL</h3>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h2> ADM MILLING - A FLOUR MILL</h3>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h2> UNIVERSITY OF MN - MPLS SE STEAM PLANT</h3>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h2> PROSPECT FOUNDRY LLC</h3>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h2> UNIVERSITY OF MN - TWIN CITIES</h3>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h2> AMERICAN IRON</h3>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h2> INNOVENT LLC</h3>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h2> XCEL ENERGY RIVERSIDE GENERATING PLANT</h3>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABHsAAAJtCAYAAACmDnxSAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nOzdeZgdVYE3/u9JAgTZFImKICQgAZGEJIQAKoQALyiyyQ+QgRHRFzCjjoMLgjoD6E9GHFERGMQFQRBRAQVHGQeVfRgEMiwuRDEYBUGEsMgW1vP+UZW203R3urMAFp/P8/TT996qOufUqbq3+37vOXVLrTUAAAAAdMOI57oBAAAAACw9wh4AAACADhH2AAAAAHSIsAcAAACgQ4Q9AAAAAB0i7AEAAADoEGEPwDCUUl5eSrm8lPJgKeWzi7H9/qWUi4a47qWllIOG38qklLJOKeWhUsrIxdn+uVBKqaWUVz9LdS123y4LpZStSym/Xspl/mcp5e1Ls8wh1Hl6KeWT7e1tSym3P5v1Px89m+f1Itrxp1LKG5ZBuSNKKWeVUu4vpVy+tMtnYKWUi0spb30O6h3dntdrP9t1D0Up5ZBSyvfa2yu3bX1Fe//MUsoHBtn2mFLK8c9WWwGWJWEP8IJQSrmmlLJBKWW9Usr/LkFRhyS5J8mqtdYP9qnjI/292SmlrFFKebyUskmt9axa645LUH+/SilzSyk7LLhfa/1DrXXlWutTS7uuQdpwerufD5VS7i2l/LiUstEyqGds+8/7qKVddlv+0aWUbyxhGdNKKRe2b4Dvbc+/dwy0fq31ilrrhr22X+h4Lo5a65tqrV9fnG3b/n24PZZ/LKV8blkGh0s7GCqlHFhKuXJplbcslFJ+2fbvQ6WUp0op83vd/+gitt2olPLkUmzLt0opj/Wq/6FSyjVD3Hz7JFslWbPWus3SatPzSSllZinlJ891O/qqtW5Xa/32kpQxlH0rpVxdSvn7JalnkLI3al9vFufc61et9cu11rcMsOxttdbPtXXvUkqZ3Wf5x2qthy5J/QDPF8IeoPNKKcslWTfJb5NslmRJwp51k/yq1lr7WXZmkteVUsb1eXzfJD+vtf5iCer9W/FvtdaVk6yV5I9JTn2O2/OsK6VsleTiJJcleXWSlyb5hyRvGmD9pRpalcbS+Pu+aXsst0+yX5KDl0KZtGqtr20D2ZWTXJHkvQvu11r/9Tlo0v/fq/6Va63ThrjduklurbU+OtwKl1Vgy9+cpxbz3ANgEMIe4IVgk/w1oJmaRYQ9pZTXlVKuLaU80P5+Xfv46UnenuTD7aePC428qLXenuZN/tv6FHlAkq+3ZSw04mCguvpp0/rtkP15pZR72mkTL26XnZlknST/0bbrw31Hv5RSXllK+X47yuS3pZSDe5V9dCnlO6WUM0ozPe2XpZSpvZYf3o7ueLCU8utSyvaD9V/bF48m+U6SSX32452llJtLKfeVUv6rlLLuAPv75lLK9aWUv5RSbiulHN1r8YLRU/e3+7vVosoupfyfUsrstp9PSlIGqPeNST6a5K1t2Tcuqv/68ZkkX6+1frrWek9tzKq17tOWtW0p5fa2X/+U5LTeI1v6O57t41uWUq4qzWihG0sp2/Zq96WlmX7w30keSbJe6TVVbbDzZ1FqrbPThBGbtGW9pi37/vZc2W0o5ZQ+05lKO+WrlLJSkv9M8spen+y/sjSjo/6nrefOUspJpZTl+5Q3s5RyS3vM/70Nul6T5JQkW7Vl3d+uv3Mp5VftefzHUsqHBmjnoH1VmlFXHyql3NSeT98upYzutfywtr13lFLeOZS+GaAdI0spHy+l/KGUclcp5WullFXaxZcnGdmrvyaXZoTEpe05encp5eu91l9sbblPllLe0Z63d5dSDmuXvTvJSUm2Lb1GJJVS3lNKmdP24XdLKS9vH18w/ecfSilzkvyifXzTts/vK810sw/26oN/KaXc2vdY9GrX/22P57zSvAZsVUr5RXvefK7PvryrNK9h95ZSflhKWatPuw5u231fKeXz7bLJSY7vtY9/ah/fvTSvKQ+W5jXqfYP034DHpT3Pb2zL+WbbX//cLhtTmumYd7fbX1BKWbPXtj0jbkrzXPhpKeWEdt/nlF5/o9p9m9vWc2spZe+B9q1P+z+bZPMkX23X6T19+U19+2tRfT0cpZSNSzNt+t5Syp9LKaeVUlbutXy9Usp/tOfG3aWUf2sff28p5UcDlHluKeWIUsrLkpyTZHz56/NotVLKcaWUU3qtP700IzPvL6XMKu3fm3bZzFLK79s+nVNK2XO4+wiwTNVa/fjx46eTP0nekeT+NG9+57e3n0zyYHt7XD/brJ7kvjSBzagkf9fef2m7/PQknxykzv2T3NLr/oZJHk8ypr1/YJIrh1jXpUkOam+/Osn/SbJCkjFp3uwd36ueuUl26HV/bJKaZFR7/7IkJycZnSaAuTvJ9u2yo9v+2TnJyCSfSnJ1r/bfluSVvcpdf4B97+mbJCulGel0Y6/le6QZXfWadn//OclVvZbXJK9ub2+bZEKaDyUmJrkryR797duiyk6yRpK/JNkryXJJ3t+eBwcNsB9HJ/lGn8cG7L8+670oyVNJZgxyjmzb1v/p9niu2D52+yDHc60k89pjNKI9F+blr+fVpUn+kOS17f4vl2GcP/20sfex2DjJn5L837bc36YJxJZPsl2a59OG/ZwDffepp8xFrds+tlmSLdv9GZvk5iSH9invB0lenCYcuzvJG/s+z3qtf2eSrdvbL0kyZYB9H8pz7Zokr0zzHL45ycx22RvTnKubpHkOfLPvfg9QZ8+x6vXYu9uy102yaruvX2mXbZTkyT7rb9Qej+WTvCLJ1UmO7bX8T0neMED930ryzwMs26jdh39Pc/5vnuY1bb12+cwkP+m1/s5tXRPb9b+c5MftstFtWT9sj9uK7bG4O8l72z5fNcnm7fpHpAkaX9lue3qS0/q06wvtdrsleTjJeWlG062T5vV0i3b9fdv+HJ/mPP5kkkv6tOu7bf3j0vyN2La/fWwfm5dkWnv7pUkmD9J//R6Xtt472vJHtW18YsGxSPLyJLu3/bRakguSfKtX2Vcn+ftebXwizYcLI9O8zs3tdb7fn/a1O83ryWsG2rd+9qGnniH214B9PUD/PDnAso3TvDYsl2TNNM+7Ba8Zyyf5TVv2i9qf17XL3pvkR+3tldu2vqK9f26SI9rbuySZ3afO45Kc0t5evz3O26V53d0tyZ/bYzEmyb356/NgrSQbDdaPfvz48fNs/xjZA3RWrfW0WuuLk8xK86ZxYppPklettb641vq7fjZ7c5qw5sxa65O11rOTzE6y6xCr/V6Sl5e/jtA5IMl/1lrvXpK6aq2/rbX+uNb6WFvW55JMH0qDSimvSvKGJIfXWufXWm9I8tUsPALpylrrhbW5xs+ZSTZtH38qzRupjUspy9Va59Za5wxS3YdKM5LiwbbO3nW8K8mnaq0311qfTPKvSSaVfkb31FovrbX+vNb6dK31piRnL2J/Byt75zQju86ttT6R5pPsZ3yCPZAh9t8CL0nzpuDORRT7dJKj2uM5lOkvf5/kwvYYPV1r/XGS69Ls2wKn11p/2Z5LT/TeeDHPn/8tpdyX5D/S7O9paZ5HK6d5s/p4rfXiNCHE3w1hH4alNqOhrm73Z26SL/XT5mNrrffXWv+Q5JL0GUnWxxNpzuNVa6331Vr7HeE3xL46odZ6R6313jT9s6DefdKEEb+otT6cJjhcXPsn+Uyt9fe11r8k+ViS/Usp/Y5Kq7XOrrVe3B6XP6U5z4f0GtH6WDt6YcHPl/osP6o9/69N8zo1cZB2f7nWelOtdX6SDyfZvrQXyG0d0x63R9MGtbXWk9o+/0tbR9I8r49o+3p+ko+nGXXXuw8+0W73/fb+GbXWee05cVWSyb3K+mSt9Tft8+PjSd5Q2lFHrX9t6/9dmpBvsPPpySSvLaWs0tZ3fX8rLeK4bJNkfq31lPY8/1aSG3tte1et9YJa66O11gfSBPGDHdNf11rPaF/Hv55k3bLwCL5NSimja61/rLXePEg5QzVQfw2lr3sb2efce2+S1Fp/1f4teKLWemeSE/LX/Z+e5m/TkbXWR9qfq5bCPvV2YJLvtMfv6fYcuyXJDmlew0uac2CFtk9nD1IWwLNO2AN0Uill9fafxgeSvC7NJ+e/TjNS5b5SykAXYHxlkt/3eez3aT61W6Ra6yNphoYf0L4h2T/tFK4lqauU8rLSXET1j6WUvyT5RpoRK0PxyiT31lofHKSe3uHHI0lGl1JG1Vp/m+TQNG9a/9y24ZWD1HVcG7CNTfJomv5eYN0kX1jwD32aT0VL+t/fLUopl7RD8x9I8+nzYPs7WNmvTDM6KUlSa6297w/BUPpvgfvSvAlYs59lvd3dvnkdqnWT7N37DVGaAKp3PQPu02KeP1NqrS+pta5fa/3nWuvTafuyvb3AkJ8fw1FKGV9K+UFppvX8JU2A17fNfc/blTOw/y9NOPb7Usplvadj9Kl3KH01UL0LnWt55vN7OPq+Pvw+zQiP1Qdo9ytLKef0avdX+2n3YI6pTQi+4OddvZY9VWu9p9f9wfp6oXbXWu9PM7Ku9znSu49eleQZAXL7+vmqJBf2OuevT/O/60t7tWter80eTTOyqvf9Be1cN8kpvcq6O01g0/sbpYZzPu2R5pz6Q2mmoE3tb6VFHJdXJul7YfLbem27Smmm7/2h3faiDH5M+7Y/SVautd6X5m/R+5L8qTRTUpfGN8QN1F9D6evenupz7p2UJKWUtdtpV3e0+39K/rr/r0ryuz6vRUvbukkO7PO6OynNSNd5aaZ1vz/JXaWZYrf+MmwLwLAJe4BOqrXe24YO70ry1fb2j5Ls2v4zOdBXq96R5h+83tZJc7Hhofp6mk/4/0+SVdKMfFjSuj6VZij6xFrrqmlGevT+dLsO0p47kqxeFr5+x5D3qdb6zVrrG9q21jTTjxa1zR+S/FOaAGbF9uHbkryrzz/1Kw7waew3k3w/yatqraul+Sd/wf72t6+DlX1nmjcGSRZ6Ezlg8/vcH3L/tWHf/6R5EziYwY5Xf8tvS3Jmn/1bqdZ67BDLXNT5M1R3JHlVWfgC0EM9lx5JM9Vigd4jPfpr+xfTjCDZoG3zRzP0Nj+jvFrrtbXW3ZO8LMn5aa4p1Z8l6auFzrU0fbO4+r4+rJMmvLg3/ffXZ9JMY9qkbfdBWbxjvKQWancpZbU0U316nyO9239bmukyC2lD2T8m2a7PeT+6T/A0VLclObCf14hZQ9i2v/Ppf2qtu6SZanVRmtGH/RnsuNyZZwYgvc+fI9rlm7fb7pjFPKa11h/WWrdPEzD9Ic3zK1n0a9FQ1+ltSfq6t88meSDJxu3+z8xf9/+2JOMGGuk2RIvar9vSTOnq+7p7YpLUWr9fa90uTZB5R5rrVwE8bwh7gK7r/e1bk9NM6RrMhWku2LhfKWVUKeWtaa4bMFBg058r0ly/4Mtprq/w+FKoa5UkD6W5KPFaSQ7rs/yuJOv1V0mt9bY00xk+VZoLkU5Mc/2Vsxa1I6WUDUsp25VSVkhzXZ9H00ztWqTaTDW6I83X1SdNYPORUspr27JXK6XsPcDmq6QZTTO/lDItzbdBLXB3mtEzvfd3sLJ/mGao/Z6luWD1+7Jw0NDXXUnGLgg0FqP/Ppzm0+DDSikvbduzaSnlW4PU2V8beu/fN5LsWkrZqTQXrR1dmos6D/RJeV+LOn+G6mdp3rh+uJSyXGkuEr1rmmu+LMoNSfZr2//GLDwd5a4kL22Dgd5t/kuSh0opG6X5RrOhuivJ2qW9oHMpZflSyv6llNXaaSV/ycDn8ZL01XfSHPuNSykvSnLUMLbt6+w00yLXaYPGTyb5ZhuC/DnN1JfeYdKCdv+lffwDS1D3kjg7ycGllE1Kc+HqTye5uJ3C1J/zk7y6NBdtXr6UsmopZfN22SlJji3NVMoFo66GOqW2r1OS/HMpZcO2rJeUUhYVyi5wV5qQc7l225VKKfuWUlZNMz3wwSz6fOrvuFyeZMVSyiHt34B98tcptAu2fSTNubhGmmuRDVspZa3SXPT+RUkea9uzoL0L7dsABvz7MoAl6eveVknTt38ppYxNM4pmgcvS7MvHSykrllJeVAb4goNB3JVm2vVKAyw/PcnflVJmlFJGtPXsUEp5eSnlVaW56PuKaf42Ppwh/m0EeLYIe4Cu2yzNtUdemmao+H2DrdwOzd4lyQfTXJjxw0l2Gc4nye2bsTPSfLp9xlKq6+NJpqT5lPOHaS6M2dun0vxzfX/p/1uG/i7N1Ko70lxX6Kg2jFmUFZIcm+SeNEP2X5ZmhMVQfSZNMLBCrfV7ad74fasdkv+LDPB15GkuTvuJUsqDSY5Mr1EY7eiZY5L8d7u/Ww5Wdtufe7f7MS/JBkn+e5A2n9P+nldKWRAUDrn/2tFE27U/t5ZS7k0T/F04SJ19LXQ828Bp9zR9f3eaT5wPy9D/ji/q/BmSNrjcLU3f3pPmotUHDPFaFf+UJhi6P82UkvN7lTs7TUhwa7vPr0zyoTQh34NJvpLk28No6sVJfplmysqC59Pbksxtz4+ZaUbs9Gex+6rW+p9prslycZoLWV88jDb39cW27qvSTHO6N21Q0L6O/VuSWW1/TUrzPHlD2+7vpblQ8XD8S/nrtxI9VNpvhxuuWusP0py/30/zfHlF+r++1YL170szCnLfNCHWr9PsR9Ls40+SXNy+FlyV5tgsTrvOTjPy4rvtOXBDW+9Q/CjNhbn/3Ktf3plmutoDaa7N9vYBth3wuNTmmkV7JvnHNFNA90jyX2lCjKS5WPAaaV63rszwXkN6G5nkI2lew+elucj2Pw6yb319Ps3U5PtK+41Xg1nCvu7tn5PMSBPOnpu/vjYveC16U5pv2Pxjuw9D+mbAXmal2f8/tM+j3mFzaq23pPnb8ck0/TY3Tb+VNBfU/liawOieNNO7/mmY9QMsU6V5TwIAADyXSik3prnw+EDTwgBgSIzsAQCA50A7Rehl7bTIQ9Jcv2gooy4BYFCjnusGAADAC9Rr00xRfFGaqX97LuYFqAFgIaZxAQAAAHSIaVwAAAAAHbLMp3GtscYadezYscu6GgAAAIAXjFmzZt1Tax3T37JlHvaMHTs211133bKuBgAAAOAFo5Ty+4GWmcYFAAAA0CHCHgAAAIAOEfYAAAAAdMgyv2YPAAAALK4nnngit99+e+bPn/9cNwWeE6NHj87aa6+d5ZZbbsjbCHsAAAB43rr99tuzyiqrZOzYsSmlPNfNgWdVrTXz5s3L7bffnnHjxg15O9O4AAAAeN6aP39+XvrSlwp6eEEqpeSlL33psEe2CXsAAAB4XhP08EK2OOe/sAcAAACgQ1yzBwAAgL8ZY4/44VItb+6xb17kOqWUfOADH8hnP/vZJMlxxx2Xhx56KEcfffQS13/ggQdml112yV577bXEZQ3mnHPOyZFHHplXvOIVueSSSxa5/nXXXZczzjgjJ5xwwoDrnH766bnuuuty0kknDbjOpZdemuWXXz6ve93rkiSnnHJKXvSiF+WAAw4Y/k4wZMIeAAAAGMQKK6yQ7373u/nIRz6SNdZY47luTo+nnnoqI0eOHNK6p556ak4++eTMmDFjSOtPnTo1U6dOXZLmJWnCnpVXXrkn7Jk5c+YSl8mimcYFAAAAgxg1alQOOeSQfP7zn3/GsgMPPDDnnntuz/2VV145SRNyTJ8+Pfvss0/Gjx+fI444ImeddVamTZuWCRMmZM6cOT3b/OQnP8nWW2+d8ePH5wc/+EGSJsg57LDDsvnmm2fixIn50pe+1FPujBkzst9++2XChAnPaM/ZZ5+dCRMmZJNNNsnhhx+eJPnEJz6RK6+8MjNnzsxhhx220Ppvfetbc+GFFy60P+edd14uvfTS7LLLLkmSe++9N3vssUcmTpyYLbfcMjfddNMz6v2P//iPbLHFFpk8eXJ22GGH3HXXXZk7d25OOeWUfP7zn8+kSZNyxRVX5Oijj85xxx2XJLnhhhuy5ZZbZuLEiXnLW96S++67L0my7bbb5vDDD8+0adMyfvz4XHHFFUmSX/7yl5k2bVomTZqUiRMn5pZbbhn0uL2QCXsAAABgEd7znvfkrLPOygMPPDDkbW688cZ84QtfyM9//vOceeaZ+c1vfpNrrrkmBx10UE488cSe9ebOnZvLLrssP/zhDzNz5szMnz8/p556alZbbbVce+21ufbaa/OVr3wlv/vd75Ik11xzTY455pj86le/Wqi+O+64I4cffnguvvji3HDDDbn22mtz/vnn58gjj8zUqVNz1lln5TOf+cxC2+y777759re/nSR5/PHH89Of/jQ777zzQuscddRRmTx5cm666ab867/+a79TsN7whjfk6quvzvXXX5999903//Zv/5axY8dm5syZef/7358bbrghW2+99ULbHHDAAfn0pz+dm266KRMmTMjHP/7xnmVPPvlkrrnmmhx//PE9j59yyin5p3/6p9xwww257rrrsvbaaw/5WLzQmMYFAAAAi7DqqqvmgAMOyAknnJAVV1xxSNtsvvnmWXPNNZMk66+/fnbcccckyYQJExa6bs4+++yTESNGZIMNNsh6662X2bNn56KLLspNN93UM2rogQceyC233JLll18+06ZNy7hx455R37XXXpttt902Y8aMSZLsv//+ufzyy7PHHnsM2MY3velNed/73pfHHnssP/rRj7LNNts8Y/+uvPLKnHfeeUmS7bbbLvPmzXtG6HX77bfnrW99a+688848/vjj/bavtwceeCD3339/pk+fniR5+9vfnr333rtn+Z577pkk2WyzzTJ37twkyVZbbZVjjjkmt99+e/bcc89ssMEGg9bxQmZkDwAAAAzBoYcemlNPPTUPP/xwz2OjRo3K008/nSSptebxxx/vWbbCCiv03B4xYkTP/REjRuTJJ5/sWdb3q7VLKam15sQTT8wNN9yQG264Ib/73e96wqKVVlqp3/bVWoe9T6NHj862226b//qv/8q3v/3t7LvvvkMqt2+b//Ef/zHvfe978/Of/zxf+tKXMn/+/GG3pbcFfTVy5Mievtpvv/3y/e9/PyuuuGJ22mmnXHzxxUtUR5cJewAAAGAIVl999eyzzz459dRTex4bO3ZsZs2alSS54IIL8sQTTwy73HPOOSdPP/105syZk1tvvTUbbrhhdtppp3zxi1/sKe83v/nNQiFTf7bYYotcdtllueeee/LUU0/l7LPP7hk5M5h99903p512Wq644orstNNOz1i+zTbb5KyzzkrSXDNojTXWyKqrrrrQOg888EDWWmutJMnXv/71nsdXWWWVPPjgg88oc7XVVstLXvKSnuvxnHnmmYts66233pr11lsv73vf+7Lbbrv1e+0gGqZxAQAA8DdjKF+Vvix98IMfXOirxg8++ODsvvvumTZtWrbffvsBR90MZsMNN8z06dNz11135ZRTTsno0aNz0EEHZe7cuZkyZUpqrRkzZkzOP//8QctZc80186lPfSozZsxIrTU777xzdt9990XWv+OOO+aAAw7IbrvtluWXX/4Zy48++ui84x3vyMSJE/OiF71ooTCn9zp777131lprrWy55ZY91xfadddds9dee+WCCy5Y6DpFSRMKzZw5M4888kjWW2+9nHbaaYO289vf/na+8Y1vZLnllssrXvGKHHnkkYvctxeqsjjDvIZj6tSp9brrrlumdQAAANBNN998c17zmtc8182A51R/z4NSyqxa69T+1jeNCwAAAKBDhD0AAAAAHTKksKeUslMp5eJSyp9KKY+VUm4vpXynlLLxsm4gAAAAAEM31As0r55kVpKTk9ydZJ0kRyS5upQyodb6+2XUPgAAAACGYUhhT6317CRn936slHJNktlJ9kry2aXfNAAAAACGa0mu2TOv/f3E0mgIAAAAAEtuqNO4kiSllJFJRiZZN8mxSf6U5FvLoF0AAADwTEevtpTLe2CRq5RS8oEPfCCf/WwzqeW4447LQw89lKOPPnqJqz/wwAOzyy67ZK+99lrisgZzzjnn5Mgjj8wrXvGKXHLJJUtU1uzZs7PvvvumlJJzzz0366+//lJq5bI3d+7cXHXVVdlvv/2WuKzzzz8/48ePz8YbN5czPvLII7PNNttkhx12WOKyl9Swwp4kP0uyWXv7t0m2q7X+ue9KpZRDkhySJOuss84SNRAAltTYI3447G3mHvvmZdASAOBv0QorrJDvfve7+chHPpI11ljjuW5Oj6eeeiojR44c0rqnnnpqTj755MyYMWOJ6z3//POz++675+Mf//iQ1q+1ptaaESOe+y8Enzt3br75zW8utbBnl1126Ql7PvGJTyxxmUvLcHv6bUm2TLJfkr8k+XEpZWzflWqtX661Tq21Th0zZswSNxIAAACeK6NGjcohhxySz3/+889YduCBB+bcc8/tub/yyisnSS699NJMnz49++yzT8aPH58jjjgiZ511VqZNm5YJEyZkzpw5Pdv85Cc/ydZbb53x48fnBz/4QZImyDnssMOy+eabZ+LEifnSl77UU+6MGTOy3377ZcKECc9oz9lnn50JEyZkk002yeGHH56kCSGuvPLKzJw5M4cddtgztvnMZz7TU89RRx2VpAlFXvOa1+Tggw/Oa1/72uy444559NFHc+GFF+b444/PV7/61Z7g6HOf+1w22WSTbLLJJjn++OMX2v7d7353pkyZkttuuy0/+tGPMmXKlGy66abZfvvtkyQPP/xw3vnOd2bzzTfP5MmTc8EFFyRJTj/99Oyxxx7ZddddM27cuJx00kn53Oc+l8mTJ2fLLbfMvffemySZM2dO3vjGN2azzTbL1ltvndmzZ/ccl/e973153etel/XWW6/nGB1xxBG54oorMmnSpGccz4ceeijbb799pkyZkgkTJvS0JUnOOOOMTJw4MZtuumne9ra35aqrrsr3v//9HHbYYZk0aVLmzJmz0Lnw05/+NJMnT86ECRPyzne+M4899liSZOzYsTnqqKN66ljQ3ssuuyyTJk3KpEmTMnny5Dz44IPPOE7DMdxtJQ0AACAASURBVKyRPbXWm9ubPyul/GeSuWm+lWvmErUCAAAAnsfe8573ZOLEifnwhz885G1uvPHG3HzzzVl99dWz3nrr5aCDDso111yTL3zhCznxxBMXCkYuu+yyzJkzJzNmzMhvf/vbnHHGGVlttdVy7bXX5rHHHsvrX//67LjjjkmSa665Jr/4xS8ybty4heq74447cvjhh2fWrFl5yUtekh133DHnn39+jjzyyFx88cU57rjjMnXq1IW2ueiii3LLLbfkmmuuSa01u+22Wy6//PKss846ueWWW3L22WfnK1/5SvbZZ5+cd955+fu///vMnDkzK6+8cj70oQ9l1qxZOe200/Kzn/0stdZsscUWmT59el7ykpfk17/+dU477bScfPLJufvuu3PwwQfn8ssvz7hx43rCmmOOOSbbbbddvva1r+X+++/PtGnTeqZB/eIXv8j111+f+fPn59WvfnU+/elP5/rrr8/73//+nHHGGTn00ENzyCGH5JRTTskGG2yQn/3sZ3n3u9+diy++OEly55135sorr8zs2bOz2267Za+99sqxxx6b4447ridU62306NH53ve+l1VXXTX33HNPttxyy+y222751a9+lWOOOSb//d//nTXWWCP33ntvVl999ey22279TsGbP39+DjzwwPz0pz/N+PHjc8ABB+SLX/xiDj300CTJGmuskf/93//NySefnOOOOy5f/epXc9xxx+Xf//3f8/rXvz4PPfRQRo8ePeTzrD+LPYaq1np/mqlcr16iFgAAAMDz3KqrrpoDDjggJ5xwwpC32XzzzbPmmmtmhRVWyPrrr98T1kyYMCFz587tWW+fffbJiBEjssEGG2S99dbL7Nmzc9FFF+WMM87IpEmTssUWW2TevHm55ZZbkiTTpk17RtCTJNdee2223XbbjBkzJqNGjcr++++fyy+/fNA2XnTRRbnooosyefLkTJkyJbNnz+6pZ9y4cZk0aVKSZLPNNluozQtceeWVectb3pKVVlopK6+8cvbcc89cccUVSZJ11103W265ZZLk6quvzjbbbNPT7tVXX72n/mOPPTaTJk3Ktttum/nz5+cPf/hDkmTGjBlZZZVVMmbMmKy22mrZddddF+q/hx56KFdddVX23nvvTJo0Ke9617ty55139rRtjz32yIgRI7LxxhvnrrvuGrQfkma62Uc/+tFMnDgxO+ywQ/74xz/mrrvuysUXX5y99tqrZwrfgrYP5Ne//nXGjRuX8ePHJ0ne/va3L3Qc9txzz2f06etf//p84AMfyAknnJD7778/o0YN96o7C1vsrUspL0+yUZKzlqgFAAAA8Dfg0EMPzZQpU/KOd7yj57FRo0bl6aefTtKEBY8//njPshVWWKHn9ogRI3rujxgxIk8++WTPslLKQvWUUlJrzYknnpiddtppoWWXXnppVlpppX7bV2sd9j7VWvORj3wk73rXuxZ6fO7cuQu1f+TIkXn00UeHVWfvdtZan7GfCx4/77zzsuGGGy70+M9+9rNF9t/TTz+dF7/4xbnhhhv6rb/39kPpm7POOit33313Zs2aleWWWy5jx47N/PnzB2z7QBZV14J2jRw5suc8OOKII/LmN785F154Ybbccsv85Cc/yUYbbTTkOvsa0sieUsr3Sin/UkrZvZQyo5TyriSXJXkyyWcXu3YAAAD4G7H66qtnn332yamnntrz2NixYzNr1qwkyQUXXJAnnnhi2OWec845efrppzNnzpzceuut2XDDDbPTTjvli1/8Yk95v/nNb/Lwww8PWs4WW2yRyy67LPfcc0+eeuqpnH322Zk+ffqg2+y000752te+loceeihJ8sc//jF//vMzvodpQNtss03OP//8PPLII3n44Yfzve99L1tvvfUz1ttqq61y2WWX5Xe/+12S9Ezj2mmnnXLiiSf2BCTXX3/9kOteddVVM27cuJxzzjlJmpDlxhtvHHSbVVZZZcDr4TzwwAN52cteluWWWy6XXHJJfv/73ydJtt9++3znO9/JvHnzFmr7QGVttNFGmTt3bn77298mSc4888xFHoc5c+ZkwoQJOfzwwzN16tSea/ksrqGO7Lk6yT5JPphk+SS3Jbk0yadqrXOXqAUAAAAwVEP4qvRl6YMf/GBOOumknvsHH3xwdt9990ybNi3bb7/9gKNuBrPhhhtm+vTpueuuu3LKKadk9OjROeiggzJ37txMmTIltdaMGTMm559//qDlrLnmmvnUpz6VGTNmpNaanXfeObvvvvug2+y44465+eabs9VWWyVpLjD9jW98Y8jf8jVlypQceOCBmTZtWpLkoIMOyuTJk58x5WvMmDH58pe/nD333DNPP/10Xvayl+XHP/5x/uVf/iWHHnpoJk6cmFprxo4d2+/1dAZy1lln5R/+4R/yyU9+Mk888UT23XffbLrppgOuP3HixIwaNSqbbrppDjzwwLz//e/vWbb//vtn1113zdSpUzNp0qSekTWvfe1r87GPfSzTp0/PyJEjM3ny5Jx++unZd999c/DBB+eEE05Y6CLdo0ePzmmnnZa99947Tz75ZDbffPPMnDn4pY6PP/74XHLJJRk5cmQ23njjvOlNbxpyH/SnLM4wr+GYOnVqve6665ZpHQAwGF+9DgB/u26++ea85jWvea6bAc+p/p4HpZRZtdap/a3/3H/JPQAAAABLjbAHAAAAoEOEPQAAADyvLevLj8Dz2eKc/8IeAAAAnrdGjx6defPmCXx4Qaq1Zt68eRk9evSwthvqt3EBAADAs27ttdfO7bffnrvvvvu5bgo8J0aPHp211157WNsIewAAAHjeWm655TJu3LjnuhnwN8U0LgAAAIAOEfYAAAAAdIiwBwAAAKBDhD0AAAAAHSLsAQAAAOgQYQ8AAABAhwh7AAAAADpE2AMAAADQIcIeAAAAgA4R9gAAAAB0iLAHAAAAoEOEPQAAAAAdIuwBAAAA6BBhDwAAAECHCHsAAAAAOkTYAwAAANAhwh4AAACADhH2AAAAAHSIsAcAAACgQ4Q9AAAAAB0i7AEAAADoEGEPAAAAQIcIewAAAAA6RNgDAAAA0CHCHgAAAIAOEfYAAAAAdIiwBwAAAKBDhD0AAAAAHSLsAQAAAOgQYQ8AAABAhwh7AAAAADpE2AMAAADQIcIeAAAAgA4R9gAAAAB0iLAHAAAAoEOEPQAAAAAdIuwBAAAA6BBhDwAAAECHCHsAAAAAOkTYAwAAANAhwh4AAACADhH2AAAAAHSIsAcAAACgQ4Q9AAAAAB0i7AEAAADoEGEPAAAAQIcIewAAAAA6RNgDAAAA0CHCHgAAAIAOEfYAAAAAdIiwBwAAAKBDhD0AAAAAHSLsAQAAAOgQYQ8AAABAhwh7AAAAADpE2AMAAADQIcIeAAAAgA4R9gAAAAB0iLAHAAAAoEOEPQAAAAAdIuwBAAAA6BBhDwAAAECHCHsAAAAAOkTYAwAAANAhwh4AAACADhH2AAAAAHSIsAcAAACgQ4Q9AAAAAB0i7AEAAADoEGEPAAAAQIcIewAAAAA6RNgDAAAA0CHCHgAAAIAOEfYAAAAAdIiwBwAAAKBDhD0AAAAAHSLsAQAAAOgQYQ8AAABAhwh7AAAAADpE2AMAAADQIcIeAAAAgA4R9gAAAAB0iLAHAAAAoEOEPQAAAAAdIuwBAAAA6BBhDwAAAECHCHsAAAAAOkTYAwAAANAhwh4AAACADhH2AAAAAHSIsAcAAACgQ4Q9AAAAAB0i7AEAAADoEGEPAAAAQIcIewAAAAA6RNgDAAAA0CHCHgAAAIAOEfYAAAAAdIiwBwAAAKBDhD0AAAAAHSLsAQAAAOgQYQ8AAABAhwh7AAAAADpE2AMAAADQIcIeAAAAgA4R9gAAAAB0iLAHAAAAoEOEPQAAAAAdIuwBAAAA6BBhDwAAAECHCHsAAAAAOkTYAwAAANAhwh4AAACADhH2AAAAAHSIsAcAAACgQ4Q9AAAAAB0i7AEAAADoEGEPAAAAQIcIewAAAAA6RNgDAAAA0CHCHgAAAIAOEfYAAAAAdIiwBwAAAKBDhD0AAAAAHSLsAQAAAOgQYQ8AAABAhwh7AAAAADpE2AMAAADQIcIeAAAAgA4R9gAAAAB0iLAHAAAAoEOEPQAAAAAdIuwBAAAA6BBhDwAAAECHCHsAAAAAOkTYAwAAANAhwh4AAACADhH2AAAAAHSIsAcAAACgQ4Q9AAAAAB0i7AEAAADoEGEPAAAAQIcIewAAAAA6RNgDAAAA0CHCHgAAAIAOEfYAAAAAdIiwBwAAAKBDhD0AAAAAHSLsAQAAAOgQYQ8AAABAhwh7AAAAADpE2AMAAADQIcIeAAAAgA4R9gAAAAB0yCLDnlLKXqWU80opvy+lPFpK+XUp5VOllFWejQYCAAAAMHRDGdnzoSRPJflokjcm+WKSf0jy41KKkUEAAAAAzyOjhrDOrrXWu3vdv6yUcm+SryfZNsnFy6JhAAAAAAzfIkfm9Al6Fri2/b3W0m0OAAAAAEticadhTW9/37y0GgIAAADAkhvKNK6FlFLWSvKJJD+ptV43wDqHJDkkSdZZZ50lauDfurFH/HDY28w99s3LoCUAAADAC8GwRvaUUlZOckGSJ5O8Y6D1aq1frrVOrbVOHTNmzBI2EQAAAIChGvLInlLK6CTfT7Jekum11tuXWasAAAAAWCxDCntKKcslOS/JtCQ71Fp/vkxbBQAAAMBiWWTYU0oZkeSsJNsneXOt9epl3ioAAAAAFstQRvb8e5K9kxyT5OFSypa9lt1uOhcAAADA88dQLtD8pvb3x5L8T5+fg5ZRuwAAAABYDIsc2VNrHfsstAMAAACApWBYX70OAAAAwPObsAcAAACgQ4Q9AAAAAB0i7AEAAADoEGEPAAAAQIcIewAAAAA6RNgDAAAA0CHCHgAAAIAOEfYAAAAAdIiwBwAAAKBDhD0AAAAAHSLsAQAAAOgQYQ8AAABAhwh7AAAAADpE2AMAAADQIcIeAAAAgA4R9gAAAAB0iLAHAAAAoEOEPQAAAAAdIuwBAAAA6BBhDwAAAECHCHsAAAAAOkTYAwAAANAhwh4AAACADhH2AAAAAHSIsAcAAACgQ4Q9AAAAAB0i7AEAAADoEGEPAAAAQIcIewAAAAA6RNgDAAAA0CHCHgAAAIAOEfYAAAAAdIiwBwAAAKBDhD0AAAAAHSLsAQAAAOgQYQ8AAABAhwh7AAAAADpE2AMAAADQIcIeAAAAgA4R9gAAAAB0iLAHAAAAoEOEPQAAAAAdIuwBAAAA6BBhDwAAAECHCHsAAAAAOkTYAwAAANAhwh4AAACADhH2AAAAAHSIsAcAAACgQ4Q9AAAAAB0i7AEAAADoEGEPAAAAQIcIewAAAAA6RNgDAAAA0CHCHgAAAIAOEfYAAAAAdIiwBwAAAKBDhD0AAAAAHSLsAQAAAOgQYQ8AAABAhwh7AAAAADpE2AMAAADQIcIeAAAAgA4R9gAAAAB0iLAHAAAAoEOEPQAAAAAdIuwBAAAA6BBhDwAAAECHCHsAAAAAOkTYAwAAANAhwh4AAACADhH2AAAAAHSIsAcAAACgQ4Q9AAAAAB0i7AEAAADoEGEPAAAAQIcIewAAAAA6RNgDAAAA0CHCHgAAAIAOEfYAAAAAdIiwBwAAAKBDhD0AAAAAHSLsAQAAAOgQYQ8AAABAhwh7AAAAADpE2AMAAADQIcIeAAAAgA4R9gAAAAB0iLAHAAAAoEOEPQAAAAAdIuwBAAAA6BBhDwAAAECHCHsAAAAAOkTYAwAAANAhwh4AAACADhH2AAAAAHSIsAcAAACgQ4Q9AAAAAB0i7AEAAADoEGEPAAAAQIcIewAAAAA6RNgDAAAA0CHCHgAAAIAOEfYAAAAAdIiwBwAAAKBDhD0AAAAAHSLsAQAAAOgQYQ8AAABAhwh7AAAAADpE2AMAAADQIcIeAAAAgA4R9gAAAAB0iLAHAAAAoEOEPQAAAAAdIuwBAAAA6BBhDwAAAECHCHsAAAAAOkTYAwAAANAhwh4AAACADhH2AAAAAHSIsAcAAACgQ4Q9AAAAAB0i7AEAAADoEGEPAAAAQIcIewAAAAA6RNgDAAAA0CHCHgAAAIAOEfYAAAAAdIiwBwAAAKBDhD0AAAAAHSLsAQAAAOgQYQ8AAABAhwh7AAAAADpE2AMAAADQIcIeAAAAgA4R9gAAAAB0iLAHAAAAoEOEPQAAAAAdIuwBAAAA6BBhDwAAAECHCHsAAAAAOkTYAwAAANAhwh4AAACADhH2AAAAAHSIsAcAAACgQ4Q9AAAAAB0i7AEAAADoEGEPAAAAQIcIewAAAAA6RNgDAAAA0CHCHgAAAIAOEfYAAAAAdIiwBwAAAKBDhD0AAAAAHSLsAQAAAOgQYQ8AAABAhwh7AAAAADpE2AMAAADQIUMKe0opa5dSTiyl/E8p5ZFSSi2ljF22TQMAAABguIY6sufVSfZJcl+SK5ZdcwAAAABYEkMNey6vtb681rpzknOWZYMAAAAAWHxDCntqrU8v64YAAAAAsORcoBkAAACgQ0Yti0JLKYckOSRJ1llnnWFvP/aIHw57m7nHvnnY2zA8wz0ujgnL1NGrLcY2Dyz9dvTh9atDhnuOPQvnF7AMPU//riyWLu0LvAD5f/L5Z7GOyej9hl/RUnwtXiYje2qtX661Tq21Th0zZsyyqAIAAACAfpjGBQAAANAhwh4AAACADhH2AAAAAHTIkC/QXErZq725Wfv7TaWUu5PcXWu9bKm3DAAAAIBhG863cZ3T5/7J7e/Lkmy7VFoDAAAAwBIZcthTay3LsiEAAAAALDnX7AEAAADoEGEPAAAAQIcIewAAAAA6RNgDAAAA0CHCHgAAAIAOEfYAAAAAdIiwBwAAAKBDhD0AAAAAHSLsAQAAAOgQYQ8AAABAhwh7AAAAADpE2AMAAADQIcIeAAAAgA4R9gAAAAB0iLAHAAAAoEOEPQAAAAAdIuwBAAAA6BBhDwAAAECHCHsAAAAAOkTYAwAAANAhwh4AAACADhH2AAAAAHSIsAcAAACgQ4Q9AAAAAB0i7AEAAADoEGEPAAAA/6+9e4+3rS7rPf55BElJSUA0xBRUQLEsMURU8HIUL4gWJHpEg8zQ1KxzXqZFHhFT5CiRaRle0byhmQZyLMU7gRhooaAi5la8oB65CAiibJ7++I0li8Xaa8619t5z/ObD5/16jdfac8wB+/nusea4PHOM35BUiM0eSZIkSZKkQmz2SJIkSZIkFWKzR5IkSZIkqRCbPZIkSZIkSYXY7JEkSZIkSSrEZo8kSZIkSVIhNnskSZIkSZIKsdkjSZIkSZJUiM0eSZIkSZKkQmz2SJIkSZIkFWKzR5IkSZIkqRCbPZIkSZIkSYXY7JEkSZIkSSrEZo8kSZIkSVIhNnskSZIkSZIKsdkjSZIkSZJUiM0eSZIkSZKkQmz2SJIkSZIkFWKzR5IkSZIkqRCbPZIkSZIkSYXY7JEkSZIkSSrEZo8kSZIkSVIhNnskSZIkSZIKsdkjSZIkSZJUiM0eSZIkSZKkQmz2SJIkSZIkFWKzR5IkSZIkqRCbPZIkSZIkSYXY7JEkSZIkSSrEZo8kSZIkSVIhNnskSZIkSZIKsdkjSZIkSZJUiM0eSZIkSZKkQmz2SJIkSZIkFWKzR5IkSZIkqRCbPZIkSZIkSYXY7JEkSZIkSSrEZo8kSZIkSVIhNnskSZIkSZIKsdkjSZIkSZJUiM0eSZIkSZKkQmz2SJIkSZIkFWKzR5IkSZIkqRCbPZIkSZIkSYXY7JEkSZIkSSrEZo8kSZIkSVIhNnskSZIkSZIKsdkjSZIkSZJUiM0eSZIkSZKkQmz2SJIkSZIkFWKzR5IkSZIkqRCbPZIkSZIkSYXY7JEkSZIkSSrEZo8kSZIkSVIhNnskSZIkSZIKsdkjSZIkSZJUiM0eSZIkSZKkQmz2SJIkSZIkFWKzR5IkSZIkqRCbPZIkSZIkSYXY7JEkSZIkSSrEZo8kSZIkSVIhNnskSZIkSZIKsdkjSZIkSZJUiM0eSZIkSZKkQmz2SJIkSZIkFWKzR5IkSZIkqRCbPZIkSZIkSYXY7JEkSZIkSSrEZo8kSZIkSVIhNnskSZIkSZIKsdkjSZIkSZJUiM0eSZIkSZKkQmz2SJIkSZIkFWKzR5IkSZIkqRCbPZIkSZIkSYXY7JEkSZIkSSrEZo8kSZIkSVIhNnskSZIkSZIKsdkjSZIkSZJUiM0eSZIkSZKkQmz2SJIkSZIkFWKzR5IkSZIkqRCbPZIkSZIkSYXY7JEkSZIkSSrEZo8kSZIkSVIhNnskSZIkSZIKsdkjSZIkSZJUiM0eSZIkSZKkQmz2SJIkSZIkFWKzR5IkSZIkqRCbPZIkSZIkSYXY7JEkSZIkSSrEZo8kSZIkSVIhNnskSZIkSZIKsdkjSZIkSZJUiM0eSZIkSZKkQmz2SJIkSZIkFWKzR5IkSZIkqRCbPZIkSZIkSYXY7JEkSZIkSSrEZo8kSZIkSVIhNnskSZIkSZIKsdkjSZIkSZJUiM0eSZIkSZKkQmz2SJIkSZIkFWKzR5IkSZIkqRCbPZIkSZIkSYXY7JEkSZIkSSrEZo8kSZIkSVIhNnskSZIkSZIKsdkjSZIkSZJUiM0eSZIkSZKkQmz2SJIkSZIkFWKzR5IkSZIkqRCbPZIkSZIkSYXY7JEkSZIkSSrEZo8kSZIkSVIhNnskSZIkSZIKsdkjSZIkSZJUiM0eSZIkSZKkQmz2SJIkSZIkFWKzR5IkSZIkqRCbPZIkSZIkSYXY7JEkSZIkSSrEZo8kSZIkSVIhNnskSZIkSZIKsdkjSZIkSZJUiM0eSZIkSZKkQmz2SJIkSZIkFWKzR5IkSZIkqRCbPZIkSZIkSYXY7JEkSZIkSSrEZo8kSZIkSVIhUzV7IuJXIuJ9EfGjiLgiIt4fEXfZ3MVJkiRJkiRpdSY2eyJia+DjwD2Bw4CnAbsCn4iIX9y85UmSJEmSJGk1tpximT8A7gbsnplfA4iILwAXAs8Ejt985UmSJEmSJGk1prmN6/HAWQuNHoDMXAecATxhcxUmSZIkSZKk1Zum2XNv4Lxl5p8P7LFpy5EkSZIkSdLGiMxceYGInwLHZ+afLZn/MuDPMvMmt4JFxBHAEcPL3YELNk25K7o98MMZ/D2zUCVLlRxglh5VyQFm6VWVLFVygFl6VSVLlRxglh5VyQFm6VWVLFVywGyy3DUzd1jujWnG7AFYriMUG1w48w3AG6b8f28SEXFOZv7mLP/OzaVKlio5wCw9qpIDzNKrKlmq5ACz9KpKlio5wCw9qpIDzNKrKlmq5IDxs0xzG9dlwHbLzN92eE+SJEmSJEmdmKbZcz5t3J6l9gC+tGnLkSRJkiRJ0saYptlzCvCAiLjbwoyI2Bl40PBeL2Z629hmViVLlRxglh5VyQFm6VWVLFVygFl6VSVLlRxglh5VyQFm6VWVLFVywMhZphmg+ReBc4FrgBfRxu/5S+C2wH0y86rNXaQkSZIkSZKmM/HKnsz8MfBw4KvA24F3AuuAh9vokSRJkiRJ6svEK3skSZIkSZI0P6YZs0eSJEmSJElzwmaPJEmSJElSITZ7JEmSJEmSCtly7AJUW0TsCOwCfD0zvzd2PWsVEVsD7wBelJlfGruetRpy/BrtqXpfzMxrRi5pTYanBD4VuC9wPfDvwLsz89pRC1tBRNwfODsdKK1LERHAA4BfBbaj/V5dDJyRmevGrG21IuKuwB60HACXAl/KzG+OV9WmFxG3Au6QmReNXcvNWURsAdwR+EFmXjd2PRtj+J06BvjbzPz62PVsjIi4I5CZ+YOxa1mriHgUN+znz87MT4xc0kQRcYd5/jdfTkTsCtwiMy9YNO9A4F7Ad4APZObVY9W3WsO5ydJ9/efnLMMWwINZZl9PO26Z622xNqHMLDcB2wP7jV3HFHU+FvgkcCFwMvDAZZbZG1g/dq0TctwC+GvgR8AlwJHD/JcBPwPWA9fRDp5Gr3dCjg1NCzuEhy7MG7veCVmeRzsJWjzvSODHw/pYD1wFPH/sWqfI8hbgbxa93pn2RMDrgcuH6XrgPGCHsetdIcf1tIOiY4E9xq5nE+TZGngk8Chgy2HerYE/Al43/L7deew6p8xyKPDtRZ+Nhen64eeHgJ3HrnOKHI8G/nNR7Yun9cC5wGPHrnMT5j14DvaP9wXeCpwG/A1wt2WW+Q3aFyKj1zshyx8Pv0PnAIcO8/5g2PevH352v0+ZkPGXhiz7jl3LlPU+HvilJfOeAnxz0XZsHfDEsWudkOPlwNGLXm9H+xJn8bZsPfBRYOux652QZT3wGeBZwLZj17ORWW4PnLHod+mDwC8Apy7Zv6wDdhy73iny7Aectcy+fuGY+HXA7cauc4oczwR+sIF9/fXA/weeNXadmzCv5/UbU9fY/zCb6R97Hg4A9x0+pF8BThp2zNcBLx77l2INWZ47ZHkX8LfAFbRGz7XAUcABwKtojZ8nj13vCjmW2/gvd+K3Hrhu7HqnyHL/Ra+fPtT/fuCJwCHDhmg9cMjY9U7I8q3FNQIfAL6xJN8+wEXAiWPXu0KOhYbUwu/Q2cBzgO3Grm0NWe467MwWPhefG3bGZw+vLx1+XgLsOna9E7I8Zaj1g8P6eAatwXg1rWn6JOB0WqNup7HrXSHHQdxwMnQ4sBdwd+Aew58PH967DvjtsevdRJm73tcD9wGuGT4PZ9FOJq4CDluy3Dzs5w8dPidnDp+Va2kns9cBJw6fnX8cfgcfPXa9E7JctML0rSHn94fX3xy73glZlu7rn8ANV7v+KfACWnNuPfCIsetdIcfXgactev024IfDscrthul/Dp+lV49d74QsCyfb1w+f//fSjoO7/pJwA1leO6yHZwJPBs4HTqFdCfMIYBtg/+H1CWPXOyHL/sBPaQ3rV9HOUz5OOzc5Engh7bjmPDpuITHrZwAAFeZJREFU+AzrYj3wZtoX0DsAWwzTDsBDgDcN2+Znjl3vJsrc9b5+qLHb8/qSj16PiIOB92bmFmPXsiER8VHaTuC3MnN9RNwSOJq2sXljZj5rWG5v4MzOs/wncFpm/unw+mDgPcCxmfmiRcv9PXDvzNxvnEpXFhELl3KeSNv4L3Zr2kHT22iNBjLz6FnWtxpDlgdk5r8Pr88FvpqZT1yy3MnA9pn54BHKnEpE/IR2kPpvw+srgT/IzJOWLPe7wF9l5g4jlDnRwjoBvgf8LvA0YFfawceptN+tD2Xm+tGKnFJEvI32DdmzaN/mv5J2W/D2wAGZ+bWI2I2W65zMfMpoxU4QEV8A/i0zn71k/u8Dfwn8Cu1qvtNpt0I9ffZVTjZshz+TmX84Ybm/B/bJzN+YTWWrFxEvnnLRPWhXLHS5fxy2rzvQmh9XRMS2tC9Engz8RWYeOyw3D/v5s4AvZ+bvDa+PAF4DvCkzn7touZNoDez9x6l0skX7+o8s8/ZWtKbCh2nbahYy92iZff1naMeWj8jM64d5W9C+bb6m1/Uy7OcfmZmnD68vBV6QmW9astyzaZ+dnUYocyrDOtmH9rt0GPA7wG1pDaB3AP+QmV8Yr8LpRcTXgVdm5gnD6/vTGtfPzMw3LlruD2lX9d19nEonG7ZhF2XmIUvmHwkcnpm7RcRtaM3Rf83MPxmjzkki4iu0c9wV95MR8VLgSZm5+2wq23w8r984czVmT0S8ZcpF77pZC9k07kP7dm89QGb+DDgyIs4DToyIbWgng/Pg7sDzF73+KO3k6GNLlvsQ8FuzKmoNHgycQLss+g8z84yFNyLil2jNnhMz89Mj1bcx7gW8aJn5b6U1GXr2fdpn+t+G11vQDpqW+gHwi7Mqaq2yjS/yMuBlEbEP7WDwicBvA5dExDtpB4P/MWKZkzyMdsD9Yfj5gd4Xgadm5tcAMvOrEfFy4KXjlTmVXYH/vcz8fwLeCOyWmV+OiNcB/3emla3O7rTbbCY5iXaVT89eQhtXLKZYtudvrPai7UuuAMjMy4BDh/38MRGxbWa+cNQKp7c7bb0seB9tf3nKkuXeQ2sC9exQ4Hjgl4Hn5KKxeSJi4QqSV8zpvv6+wFMWGj0Aw4nH3wF/P15ZE11GG/dpwdbA15ZZ7kJuGJ+kZzk0rk6PiOfS9u+H0bbR/2v4kuGtwLsyc7njmV78Mm0MmAXnDz+/vGS5LwM7zqSitbsP7W6DpV5POx7bbThuOQ54MdBls4c2lMHS86vlfIx2dV+3PK+fjXl7GtfhtA3mIydMvz5SfauxFe0b/RvJzHfRvgX4bdrtKreacV1rcT03Pii/avj5oyXLXUm7FLdLmXkmsCftZOjDEfGWiNh+5LI2xuKToKtpY9ss9SPglrMpZ80+ALxwGJQZ4P/RbrVZ6hm0hsPcyMzPDN3+HWnf9v877XaIc0YtbLLb025xWPCN4efSgXK/OSzbs0uA3ZaZf0/aZ+jHw+tv0vH2i3YVwp5TLLfnsGzPvkdrJNxywvTksQqc0m1ZZrubma8Ang08f7jSah6OxW5Ju3VrwcL+/YdLlruEzj/zmflu2uf7W8AXIuLFEbHVwtvjVbZJrKd9QbLU92gNlF79C/C8iFj4LHyaduvGUgfRGj5zIzN/kpnvzsxH064U/TPal1Z/Tfsd7NnFtM/Kgnsu+bl4/sUzqWjtruLGDcUFO9I+9wtXVV8I3GFWRa3BOuB/TLHcI2jHLT07HM/rN7u5urKHdiLxkcw8YqWFIuJ3aN8u9exC2n17N+nOZuYHI+JxwD/TRovv3XdoV/ecBj//FulAbrpDvgvt6otuZRu9/piIeA/tW7ALIuLPad9izps3DLc8QTuw2I12K8piO3PTg/XevIS2sT8vIt5Iu/T+uIj4PO3zk7R7sfcADhyryI2RmT+ljXfxjxFxB9o4Mj37FnA/4FPD672Gn7/JDVdgLbz+9gzrWot/BF4+fFb+lbazfgDt6oRz84YnPd0J+O44JU7lDbRt122Bd2bmfy1+MyLuRrui4c9pV5b17Bxgz0m3NEZE77c8fp12pcWnlr6RmSdExI9p40PttfT9Dl1M218AP9/P/xE3PZm4M21cla5l5o+AI4ZbUl8PPDUinkNruM+bl0TEwn78p7QnoJ6xZJlfoe/18iLav/2ZEfEa2jp5c0TcmXa1eNIGoD+Adhv0XMr2VNpXAa+KiD3pP8upwF8O29orgf9DO2F9SUR8jbatvj9t/f3LaFVO51TaPnLdotsFd6eNfbNu0T7z9vR9rnI8cMLw2XgnbYyhy2ifke2Ae9P29YcBK97W3QHP62dg3po959BOHiaZh29mPgo8PSKOXXy57YLM/FhE7E+7iqF3n6WN33HCwozMXK7uA2kDuHZv2OjvHxFPBY6jXW0xD79XCz7Njes9h3awt9RBQNf3jmfm5RHxINpTrP6C1hUP2hNsFsYdOYc2LsbHx6ly08n2yNZXj13HBCcBLx3GILmSNpDx64CjIuJybjgA/AvaQIE9O5J2m+PbuPFn5iu0A6YFd6UNQt+rY4Hb0PIcFRHX0q4qSWBb2hNUfkb7NvkVYxU5pU+y/NV7S30D+IfNWsnG+STtm8tlP8+Z+faIuIq+f68WfJ72bfKJCzMy8++WWe4RQM+3oN5IZp4REb9Bu9riZG74AmFeXETbfi24nNY8fMeS5R7LDbfgdCczvzvs519Pq33hNs4nDBO0q5N+LzPfOU6Vm1Zmfp72uerZ0bTzroXxeT5FuxXlTbTBjRc+Kxdz49s8e/SntCyfjIhraPvDbWhfeB60aLn7MXx53aPMfGNEQPvS5rBlFglapucsHlepU57Xz8BcDdA8DMD61EkDzEXEvWhP7+l5AN1fpm1QTl+4n38Dy+1OG3yv93FVJoqIxwL/lZkXjF3LakTEdrSN6r2AP56XgfWmEREPBi5eehVAryJia9rn5k60Wx8uAc7PzO+MWtgUIuIhwOcy86qJC3cuIm5N+zbsibSrxv6B9sS3l9MGo1s4UD8XePgwVknXhs/C3rRLuS+gfdvU+5UjNxERO9C+Ad+D9i1f0L7RP5826GTP40OUEhG70q46fHdmbvCqiojYD3hY58cstwG2WinHsNwRwBcz8zOzqWzTiYh70K7ouxdtYNN5vMpnWRHxZNrVC58du5ZJhqsQH8SS/Txw1jxskyPiMODUzLxk7Fo2lWFbtlVmnr9o3gG0qxS+B7w/M6/c0H/fi+F2zUO48b7+XcOVfnNlGHh9H9qVPEv39Z8Z7lTomuf1M6ptnpo9kqR+RMStgC0XN7AiYg/g12gHgKcv9w2HJEmSpM3LZk8HImJHWnd8O9pgxxcDn8/Mq0ctbA2qZKmSA8zSoyo5qqmyXoZHft6DG55acynwteHpEHOlSpYqOcAsvaqSpUoOMEuvKmWRJsrMuZxoo6c/EngS7VaCBwNbj13XKjPsB5xFu5Rw6XQVbQyM241d580pS5UcZulzqpJjSSa3xZ1MtEd//jNwzTI5rhne+/Wx67w5ZamSwyz9TlWyVMlhln6nSlmmyHowsH7sOpzGXy9zd2XPcG/7K1n+6RXX0MaOODIzl3vMdDeGQZpOBb5Me7rQtcADgX2Bo2gbnmcM8x/cc54qWarkALOMVOqKquRY4La4LxGxL/Bh2oCtJ9Hu27+Udh//trT7+g+hPVHpUTk8jaRHVbJUyQFmGafSyapkqZIDzDJOpZNVyjKNiDgYeG9mbjF2LRvLLBv5d85Ts6fKQTlARJwFXJSZhyyZfyRweGbuNgyIeA5tUM0/GaPOaVTJUiUHmGWMOiepkgPcFo9R5yQRcSbttrNDcgODmA4DOr4H2Ckz95llfatRJUuVHGCWWda3GlWyVMkBZpllfatRJcswqPE09gKebYNkNrpeL2NeyrTaiXaZ/XuXmX8k8NXhz7ehPTL31WPXOyHL1bTO8dL529PGithteP0M2onI6DVXz1Ilh1nGr7lyjqFGt8WdTUOOh02x3MOBq8eu9+aQpUoOs4xfc/UsVXKYZfyaq2cZjkvWDz8nTV3fxgX87pTTa+cgS7fr5RbMl/vQHve71OuBe0TEbtmeCnMccNBMK1u9q4A7LjN/R9pjixe6zhcCd5hVUWtUJUuVHGCWHlXJAW6Le3Q5sMsUy+0yLNuzKlmq5ACz9KpKlio5wCy9qpLlUtpt8rtOmJ43VoGr8FbgxOHnStNzZlzXWnS7Xrac9V+4kaoclEO7BeKYiFiXw32hEbE77QRqXWb+17Dc7YEfjFTjtKpkqZIDzNKjKjnAbXGP3gkcFxHX0a66+sniNyPiVrQBtF9JO7jqWZUsVXKAWXpVJUuVHGCWXlXJ8jngbouOTZYVERfPqJ6NcSnwQeBlE5Z7DPA3m7+cjdLvehn7sqdVXiL1FuDbwL6L5u0OfJb2yLyFeQfT8eX2Q43bA1/ghqe9XDb8+fvAgxYtdwzw5rHrvTlkqZLDLOPXXDnHUKPb4s4m4BdoB7PXAz+hjad0JnDG8OefDO+9G/iFseu9OWSpksMs49dcPUuVHGYZv+bqWWjHIldMsdx+wCfGrndCjR8GPjXFct0/Wazn9TJvAzRvD3yCNmL6NcDPgG2AHwIHZeYZw3LHAHfMzN8fq9ZpRMRWtJHf96adXFwAvCszfzRqYWtQJUuVHGCWHhXK4ba4UxHx68DjgT2A7WhPGrmU9uSRUzLz3BHLW5UqWarkALP0qkqWKjnALL2qlGXeDceIz83MbSYstx9wdGY+bDaV1TJXzR6odVAuSfPKbbEkSZLUr7lr9lQUEbcA7k7rMF8PXJyZ3x63qrWpkqVKDjBLj6rkqKbSeomIrYFth5eXZebVY9azMapkqZIDzNKrKlmq5ACz9KpKlio5qulpvczb07h+LiJuERG7RsTeEbFXRNx57JpWKyJ2j4iTgCtojyg+k/ZI429GxDci4gURMReDaFfJUiUHmKVHVXIs5ra4HxFxp4h4dUSsA64ELhqmKyNi3fDeTuNWOZ0qWarkALP0qkqWKjnALL2qkqVKjqUiYuuI2GmYth67ntXqdb3M3ZU90Z6ScjTwOODWS97+FvA64PjMvG7Wta1GRNyPNubF1cDpwLW02yF2Bo6njX9xCPBF4NG5ZNT4nlTJUiUHmGWcSldWJccCt8V9iYhfpeW4Be3pFufTxiEI2rdLewAHDos/NDPPG6POaVTJUiUHmGWMOqdRJUuVHGCWMeqcRpUsVXIsiIg7AS8AngDcZcnbFwEnA6/KzO/MurbV6Hm9zFWzp8pBOUBEfHz44+MWLu2KiABeC+ydmXsNH4CzgTdl5lEjlTpRlSxVcoBZRip1RVVygNvikUpdUUScBtwSeHxmXrGBZbYBTgF+mpn7z7K+1aiSpUoOMMss61uNKlmq5ACzzLK+1aiSpUoO6LtBslpdr5dpHtnVywR8fJi2XjQvgL8Fzh5e3wn4Dm3U7tFrXiHLVcABy8zfkTbY6S7D6z8CLhy73ptDlio5zDJ+zZVzDDW6Le5sGnLsP8VyjwKuGrvem0OWKjnMMn7N1bNUyWGW8WuunqVKjqHG04BPAtussMw2wzIfGbveeV0v8zZmz/2Bv8pFgxxl+5d7ObBnROySmd8FjgWeMlKN0/oZN731gWFeAFsNr88Deh8Do0qWKjnALD2qkgPcFvfoGuB2Uyx3O6DbK60GVbJUyQFm6VWVLFVygFl6VSVLlRwA+wDH5AauhAEY3nsF8MCZVbU23a6XeWv2VDkoB/gY8NKI2GVhRkRsC7wG+B7w1WH2NsDlsy9vVapkqZIDzNKjKjnAbXGPTgaOi4j9NrRAROwLvBL455lVtTZVslTJAWbpVZUsVXKAWXpVJUuVHNBxg2QNul0v8zZmz/to9+8dkJnrhnnbAm8H9gR2ysyMiCcAJ2TmjuNVu7KI2Bk4A9gBuBD4KbArsAXwlMz8wLDc8cCumXng8v+n8VXJUiUHmGWcSldWJQe4LR6n0pVFxO1o97w/EPgurdF2GZC0R8nfG9iJ9pSxAzKz28ZVlSxVcoBZRip1oipZquQAs4xU6kRVslTJARARbwL2B56amZ/ewDL7Au8ATsvMZ8yyvtXoeb3MW7NnZwoclC+IiO2AZ9MGNl0PXEA7MVq3aJktaXdIrB+nyulUyVIlB5ilR4Vy7Izb4i4NDbYDaQcW29GutLqUNvDhKcApOSc7/ipZquQAs/SqSpYqOcAsvaqSpUKOnhska9XjepmrZg/UOiiXpHnltliSJEkbo8cGSSXzNmYPmXlpZr4sMw/MzN/KzBcuPrkYlrmuyslFROwXNzwaeK5VyVIlB5ilR/OSw21xnyLioRFxaETcdwPv7xQRL551XWtRJUuVHGCWXlXJUiUHmKVXVbJUyQGQmSdn5jMyc5/M3D0zd8vMB2Tm7w/vzU2jp8v1kh08rmxTT8B+wMfHrmMTZTkYWD92HWapl8MsfU5VcgxZ3BbPrr7bAGfSrrK6fvj5r8Cdliy3d885KmWpksMs49dcPUuVHGYZv+bqWarkWFLrQ4FDgftu4P2dgBePXee8rpctqWkH4CFjF7GSiLjLlIvusFkL2QSqZKmSA8zSoyo5Vslt8ewcCdwLOBw4m3bwdDTw2Yh4VGZ+abzSVq1Klio5wCy9qpKlSg4wS6+qZKmSg4i4DfARWgMkgIyI04CnZ+Z3Fy16Z+Ao4KWzr3Jq/a6XsTthq+ya3WXK6Vl03s3khq7fpOl6s5jDLPOfpUqOIYvb4s4m4CvA85bM2wk4B/ghsNcwr/tv+6pkqZLDLOPXXD1LlRxmGb/m6lmq5BhqPIY2IPPTgHvSjhm/D3wL2GPRcvOQpdv1Mm9X9nyDNkL3JDHlcmO6Bvg08L4Jy/0mcMTmL2ejVMlSJQeYpUdVcoDb4h7dBfiPxTMy8zsR8RDa0y4+FhGPp+XtXZUsVXKAWXpVJUuVHGCWXlXJUiUHwEHAUZn59uH1VyLig8DJwKcj4jGZefZ45a1Kt+tl3po9VQ7KAc6ldfbevNJCEXE5ZpmVKjnALD2qkgPcFvfoB7RLnW8kM38cEY8B3g98CDhu1oWtQZUsVXKAWXpVJUuVHGCWXlXJUiUHdNwgWYNu18u8PY3r5wflK03AR8cudAqfA+435bKxOQvZBKpkqZIDzNKjKjnAbXGPzgGesNwbmXnt8N6pwItmWdQaVclSJQeYpVdVslTJAWbpVZUsVXLACg0S4DHA6bQGyQEzrmstul0v89bsqXJQDnAs8ORJC2XmP2Vm7+upSpYqOcAsPaqSA9wW9+jdwF0jYvvl3szM64AnAa8HLpplYWtQJUuVHGCWXlXJUiUHmKVXVbJUyQEdN0jWoNv1EsNgQXMhInYC7pGZnxq7Fkm6uXJbLEmSpLWKiIOB5wOPy8xLNrBMAK8DHp2Zu8yyvirmqtkjSZIkSZKklfV8SbokSZIkSZJWyWaPJEmSJElSITZ7JEmSJEmSCrHZI0mSJEmSVMh/A79snHqKDYpVAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 1440x720 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "v_data['HPV_DAYZERO_DATE'] = pd.to_datetime(v_data['HPV_DAYZERO_DATE'], format=\"%m-%d-%Y\") #format\n",
+    "e_data['SETTLEMENT_ENTERED_DATE'] = pd.to_datetime(e_data['SETTLEMENT_ENTERED_DATE'], format=\"%m/%d/%Y\") #format\n",
+    "cps = v_data\n",
+    "e = e_data\n",
+    "\n",
+    "cps = cps[(cps['POLLUTANT_DESCS'].astype(str).str.lower().str.contains('particulate')) | \n",
+    "          (cps['POLLUTANT_DESCS'].astype(str).str.lower().str.contains('sulfur')) |\n",
+    "          (cps['POLLUTANT_DESCS'].astype(str).str.lower().str.contains('pm')) |\n",
+    "          (cps['POLLUTANT_DESCS'].astype(str).str.lower().str.contains('nox')) |\n",
+    "          (cps['POLLUTANT_DESCS'].astype(str).str.lower().str.contains('no2')) |\n",
+    "          (cps['POLLUTANT_DESCS'].astype(str).str.lower().str.contains('sox')) |\n",
+    "          (cps['POLLUTANT_DESCS'].astype(str).str.lower().str.contains('so2')) |\n",
+    "          (cps['POLLUTANT_DESCS'].astype(str).str.lower().str.contains('lead')) |\n",
+    "          (cps['POLLUTANT_DESCS'].astype(str).str.lower().str.contains('monoxide'))\n",
+    "         ]\n",
+    "facs = cps.index.unique() #facilities that violated CPs\n",
+    "f = e.index.isin(facs.tolist())\n",
+    "e = e[f]\n",
+    "s = e[\"PENALTY_AMOUNT\"].sum() #total that facilities paid in penalties\n",
+    "\n",
+    "cps = cps.groupby(['HPV_DAYZERO_DATE'])['POLLUTANT_DESCS'].count() \n",
+    "e = e.groupby(['SETTLEMENT_ENTERED_DATE'])['ENF_TYPE_DESC'].count() \n",
+    "\n",
+    "cps = cps.resample('Y').sum() #resample to a yearly basis  \n",
+    "cps = pd.DataFrame(cps)\n",
+    "cps = cps.rename(columns={'POLLUTANT_DESCS': \"Number of violations\"})\n",
+    "cps.index = cps.index.strftime('%Y') # makes the x axis (date) prettier\n",
+    "\n",
+    "e = e.resample('Y').sum() #resample to a yearly basis  \n",
+    "e = pd.DataFrame(e)\n",
+    "e = e.rename(columns={'ENF_TYPE_DESC': \"Number of enforcement actions\"})\n",
+    "e.index = e.index.strftime('%Y') # makes the x axis (date) prettier\n",
+    "\n",
+    "d=cps.join(e)\n",
+    "\n",
+    "ax = d.plot(kind='bar', title = \"# of Violations Related to Criteria Pollutants and Total Enforcements against the Facilities\", figsize=(20, 10), fontsize=16)\n",
+    "ax.yaxis.set_major_locator(MaxNLocator(integer=True))\n",
+    "ax\n",
+    "\n",
+    "#facility name lookup\n",
+    "facs = facs.tolist()\n",
+    "f = my_echo[\"AIR_IDS\"].isin(facs)\n",
+    "f = my_echo[f]\n",
+    "\n",
+    "#print\n",
+    "display(HTML(\"<h1>$\"+str(\"{:,.0f}\".format(s))+\"</h1>\" + \\\n",
+    "    \"The following facilities/companies paid only this much in total for their violations.\"))\n",
+    "for index,row in f.iterrows():\n",
+    "    display(HTML(\"<h2> \"+row[0]+\"</h3>\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next questions\n",
     "\n",
     "What other questions would you like to see added? Here are some I have:\n",
     "* What are the top 3 noncompliant facilities in the zip code and what are they violating?\n",
@@ -411,7 +720,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I am not actually suggesting we merge this branch into ECHO-by-Zip-Code. It's just that I started from this repo to create this notebook, and I'm not sure if it'll go anywhere. There are *some* elements that could be included here, such as using `display(HTML())` for output and calculating the social cost of GHGs released.

Reconfigures echo-by-zip to emphasize "white collar" environmental crime:
- Search by City, State rather than zip
- Display GHG emitters on the map
- Display social cost of GHG
- Display criteria pollutant CAA violations and enforcement penalties